### PR TITLE
Prepare v0.2.1 release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build package
+        run: |
+          pip install build
+          python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,49 @@
+name: Smoke
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  collect:
+    runs-on: ubuntu-22.04
+    name: pytest --collect-only
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install agentcad + test dependencies
+        run: pip install -e .[mcp,dev]
+
+      - name: Collect tests
+        run: pytest --collect-only -q
+
+      - name: Run OCP-free guardrails
+        run: pytest tests_b3d/test_parity_guardrail.py -q
+
+  windows-platform:
+    runs-on: windows-latest
+    name: Windows platform check
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install agentcad + test dependencies
+        run: pip install -e .[mcp,dev]
+
+      - name: Collect tests
+        run: pytest --collect-only -q
+
+      - name: Run Windows-relevant guardrails
+        run: pytest tests/test_daemon_platform.py tests_b3d/test_parity_guardrail.py -q

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -1,0 +1,50 @@
+name: Sync SKILL.md to public skill repo
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - "src/agentcad/commands/skill.py"
+      - "pyproject.toml"
+      - "scripts/generate_skill_md.py"
+      - ".github/workflows/sync-skill.yml"
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install pyyaml
+
+      - name: Generate SKILL.md
+        run: python scripts/generate_skill_md.py > /tmp/SKILL.md
+
+      - name: Checkout public skill repo
+        uses: actions/checkout@v4
+        with:
+          repository: jdilla1277/agentcad-skill
+          token: ${{ secrets.SKILL_SYNC_TOKEN }}
+          path: public-skill
+
+      - name: Commit and push if changed
+        working-directory: public-skill
+        run: |
+          cp /tmp/SKILL.md SKILL.md
+          git config user.name "agentcad-sync[bot]"
+          git config user.email "agentcad-sync@users.noreply.github.com"
+          if git diff --quiet -- SKILL.md; then
+            echo "SKILL.md is already up to date."
+            exit 0
+          fi
+          git add SKILL.md
+          git commit -m "Sync SKILL.md from jdilla1277/agentcad@${GITHUB_SHA}"
+          git push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.2.0"
+version = "0.2.1"
 description = "CLI CAD tool for AI agents. Write CadQuery scripts, get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/agentcad/commands/_daemon_routing.py
+++ b/src/agentcad/commands/_daemon_routing.py
@@ -64,6 +64,8 @@ def maybe_route_through_daemon(argv: list[str], no_daemon: bool = False) -> None
     """Try routing through the daemon; sys.exit on success.
 
     Returns ``None`` if direct execution should proceed:
+      * the platform can't host a daemon (Windows: no ``fork``/``AF_UNIX``/
+        ``getuid``; see ``daemon.daemon_supported``),
       * caller passed ``--no-daemon``,
       * we're already inside a daemon (``AGENTCAD_DAEMON`` env set —
         would recurse),
@@ -79,7 +81,7 @@ def maybe_route_through_daemon(argv: list[str], no_daemon: bool = False) -> None
     in-memory version differs from the client's on-disk install — so the
     silent "via:daemon stamped on stale code" trap is at least visible.
     """
-    if os.environ.get("AGENTCAD_DAEMON") or no_daemon:
+    if not _daemon.daemon_supported() or os.environ.get("AGENTCAD_DAEMON") or no_daemon:
         return None
 
     result = _route_through_daemon(argv)
@@ -116,8 +118,9 @@ def maybe_route_through_daemon(argv: list[str], no_daemon: bool = False) -> None
 def maybe_spawn_daemon_for_next_run(no_daemon: bool = False) -> None:
     """Fork off the warm process as the daemon after a successful direct
     execution. Idempotent — silently no-ops if a daemon for this venv
-    is already running, or if we're inside a daemon-routed request."""
-    if no_daemon:
+    is already running, if we're inside a daemon-routed request, or if the
+    platform can't host a daemon."""
+    if no_daemon or not _daemon.daemon_supported():
         return
     _daemon.spawn_daemon_via_fork(
         socket_path=_socket_path(),

--- a/src/agentcad/commands/daemon_cmd.py
+++ b/src/agentcad/commands/daemon_cmd.py
@@ -1,4 +1,5 @@
 import json
+import platform
 
 import click
 
@@ -6,6 +7,7 @@ from agentcad.daemon import (
     _default_pid_path,
     _default_socket_path,
     daemon_status,
+    daemon_supported,
     restart_daemon,
     start_daemon,
     stop_daemon,
@@ -18,6 +20,22 @@ def _socket_path():
 
 def _pid_path():
     return _default_pid_path()
+
+
+def _emit_unsupported(subcommand: str) -> None:
+    """Emit clean JSON when the daemon cannot run on this platform."""
+    click.echo(json.dumps({
+        "command": "daemon",
+        "subcommand": subcommand,
+        "status": "unsupported",
+        "platform": platform.system(),
+        "message": (
+            "The agentcad daemon requires POSIX primitives (os.fork, AF_UNIX, "
+            "os.getuid) and is disabled on this platform. Commands still run "
+            "directly, but each invocation pays the full OCP import cost "
+            "instead of routing through a warm worker."
+        ),
+    }))
 
 
 @click.group(hidden=True)
@@ -35,6 +53,9 @@ def daemon():
 @daemon.command()
 def start():
     """Start the daemon worker."""
+    if not daemon_supported():
+        _emit_unsupported("start")
+        return
     result = start_daemon(
         socket_path=_socket_path(),
         pid_path=_pid_path(),
@@ -47,6 +68,9 @@ def start():
 @daemon.command()
 def stop():
     """Stop the daemon worker."""
+    if not daemon_supported():
+        _emit_unsupported("stop")
+        return
     result = stop_daemon(
         socket_path=_socket_path(),
         pid_path=_pid_path(),
@@ -59,6 +83,9 @@ def stop():
 @daemon.command()
 def status():
     """Check daemon status."""
+    if not daemon_supported():
+        _emit_unsupported("status")
+        return
     result = daemon_status(
         socket_path=_socket_path(),
         pid_path=_pid_path(),
@@ -75,6 +102,9 @@ def restart():
     install --upgrade agentcad``. Equivalent to ``stop`` followed by
     ``start``, but always force-kills if graceful shutdown fails.
     """
+    if not daemon_supported():
+        _emit_unsupported("restart")
+        return
     result = restart_daemon(
         socket_path=_socket_path(),
         pid_path=_pid_path(),

--- a/src/agentcad/daemon.py
+++ b/src/agentcad/daemon.py
@@ -56,6 +56,22 @@ def _venv_tag():
     return hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:8]
 
 
+def daemon_supported():
+    """Whether this platform can host the preforked daemon.
+
+    The daemon is built on POSIX-only primitives: ``os.fork`` (prefork the
+    warm process), ``AF_UNIX`` sockets (the IPC transport), and ``os.getuid``
+    (the per-user socket/pid path). Windows has none of these, so the daemon
+    is disabled there and every command runs directly, equivalent to passing
+    ``--no-daemon`` on each call.
+    """
+    return (
+        hasattr(os, "fork")
+        and hasattr(os, "getuid")
+        and hasattr(socket, "AF_UNIX")
+    )
+
+
 def _default_socket_path():
     # Test/operator override — useful for pinning a daemon to a known path
     # in subprocess-based tests, or for running multiple daemons on a host

--- a/src/agentcad/mcp/server.py
+++ b/src/agentcad/mcp/server.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import traceback
 
 from click.testing import CliRunner
 from mcp.server.fastmcp import FastMCP
@@ -9,6 +10,28 @@ from mcp.server.fastmcp import FastMCP
 from agentcad.cli import cli
 
 mcp = FastMCP(name="agentcad")
+
+
+def _format_result(output: str, exit_code: int, exception: BaseException | None = None) -> dict:
+    """Build the MCP response dict from a Click invocation's output."""
+    try:
+        return {**json.loads(output), "_exit_code": exit_code}
+    except (json.JSONDecodeError, TypeError):
+        pass
+
+    message = output.strip() if output else ""
+    if exception is not None:
+        tb = "".join(traceback.format_exception(
+            type(exception), exception, exception.__traceback__
+        )).strip()
+        message = f"{message}\n{tb}".strip() if message else tb
+
+    return {
+        "status": "error",
+        "message": message or "No output",
+        "exit_code": exit_code,
+        "_exit_code": exit_code,
+    }
 
 
 def _invoke(args: list[str], cwd: str | None = None) -> dict:
@@ -24,17 +47,7 @@ def _invoke(args: list[str], cwd: str | None = None) -> dict:
     finally:
         os.chdir(old_cwd)
 
-    try:
-        data = json.loads(result.output)
-    except (json.JSONDecodeError, TypeError):
-        data = {
-            "status": "error",
-            "message": result.output.strip() if result.output else "No output",
-            "exit_code": result.exit_code,
-        }
-
-    data["_exit_code"] = result.exit_code
-    return data
+    return _format_result(result.output, result.exit_code, result.exception)
 
 
 @mcp.tool()

--- a/tests/test_daemon_platform.py
+++ b/tests/test_daemon_platform.py
@@ -1,0 +1,82 @@
+"""Platform-capability guards for the preforked daemon."""
+
+import json
+import os
+import socket
+
+import pytest
+
+from agentcad import daemon
+from agentcad.commands import _daemon_routing as routing
+
+
+def test_daemon_supported_matches_host_capabilities():
+    expected = (
+        hasattr(os, "fork")
+        and hasattr(os, "getuid")
+        and hasattr(socket, "AF_UNIX")
+    )
+    assert daemon.daemon_supported() is expected
+
+
+def test_daemon_supported_false_without_getuid(monkeypatch):
+    monkeypatch.delattr(os, "getuid", raising=False)
+    assert daemon.daemon_supported() is False
+
+
+def test_daemon_supported_false_without_fork(monkeypatch):
+    monkeypatch.delattr(os, "fork", raising=False)
+    assert daemon.daemon_supported() is False
+
+
+def test_daemon_supported_false_without_af_unix(monkeypatch):
+    monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+    assert daemon.daemon_supported() is False
+
+
+def test_route_noops_when_unsupported(monkeypatch):
+    monkeypatch.setattr(daemon, "daemon_supported", lambda: False)
+    monkeypatch.delenv("AGENTCAD_DAEMON", raising=False)
+    called = []
+    monkeypatch.setattr(routing, "_route_through_daemon", lambda argv: called.append(argv))
+
+    assert routing.maybe_route_through_daemon(["run", "x.py"], no_daemon=False) is None
+    assert called == []
+
+
+def test_spawn_noops_when_unsupported(monkeypatch):
+    monkeypatch.setattr(daemon, "daemon_supported", lambda: False)
+    called = []
+    monkeypatch.setattr(daemon, "spawn_daemon_via_fork", lambda **kw: called.append(kw))
+
+    routing.maybe_spawn_daemon_for_next_run(no_daemon=False)
+    assert called == []
+
+
+def test_windows_simulation_no_attributeerror(monkeypatch):
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.delattr(os, "fork", raising=False)
+    monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+    monkeypatch.delenv("AGENTCAD_DAEMON", raising=False)
+
+    assert routing.maybe_route_through_daemon(["run", "x.py"], no_daemon=False) is None
+    routing.maybe_spawn_daemon_for_next_run(no_daemon=False)
+
+
+@pytest.mark.parametrize("subcommand", ["start", "stop", "status", "restart"])
+def test_daemon_subcommand_emits_unsupported_json_on_windows(
+    runner, monkeypatch, subcommand
+):
+    from agentcad.cli import cli
+
+    monkeypatch.delattr(os, "getuid", raising=False)
+    monkeypatch.delattr(os, "fork", raising=False)
+    monkeypatch.delattr(socket, "AF_UNIX", raising=False)
+
+    result = runner.invoke(cli, ["daemon", subcommand])
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "daemon"
+    assert parsed["subcommand"] == subcommand
+    assert parsed["status"] == "unsupported"
+    assert "POSIX" in parsed["message"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,7 +5,7 @@ import os
 
 import pytest
 
-from agentcad.mcp.server import mcp, _invoke
+from agentcad.mcp.server import mcp, _format_result, _invoke
 
 
 # --- Tool registration ---
@@ -114,6 +114,30 @@ def test_run_tool_missing_script_error(tmp_path, monkeypatch):
 def test_inspect_tool_missing_file_error():
     result = _invoke(["inspect", "/tmp/nonexistent.step"])
     assert result["_exit_code"] != 0
+
+
+def test_format_result_surfaces_exception_traceback():
+    try:
+        raise RuntimeError("kaboom on windows")
+    except RuntimeError as exc:
+        data = _format_result("", 1, exception=exc)
+
+    assert data["status"] == "error"
+    assert "kaboom on windows" in data["message"]
+    assert "RuntimeError" in data["message"]
+    assert data["_exit_code"] == 1
+
+
+def test_format_result_no_output_without_exception():
+    data = _format_result("", 1)
+    assert data["message"] == "No output"
+    assert data["_exit_code"] == 1
+
+
+def test_format_result_parses_json_output():
+    data = _format_result('{"status": "success", "command": "context"}', 0)
+    assert data["status"] == "success"
+    assert data["_exit_code"] == 0
 
 
 def test_docs_mcp_section():

--- a/tests_b3d/test_parity_guardrail.py
+++ b/tests_b3d/test_parity_guardrail.py
@@ -63,6 +63,8 @@ PARITY_MAP: dict[str, str] = {
         "cq_only:env check, runtime-agnostic CLI wiring",
     "test_end_to_end_workflow":
         "cq_only:smoke test exercising all commands; pieces covered piecewise on b3d",
+    "test_run_emits_json_error_on_unexpected_exception_after_script_start":
+        "cq_only:CLI catch-all error wrapper; monkeypatches compute_metrics — runtime-agnostic, the wrapper sits above runtime dispatch",
     "test_run_no_manifest_error":
         "cq_only:CLI error orthogonal to runtime",
     "test_run_script_not_found_error":


### PR DESCRIPTION
Patch release prep for v0.2.1.

### Changes
- Disable the POSIX-only daemon cleanly on unsupported platforms such as Windows.
- Return clean JSON from `agentcad daemon {start,stop,status,restart}` when the daemon is unsupported.
- Surface MCP traceback details when Click catches an unexpected exception with no JSON output.
- Restore root-layout Smoke, publish, and skill-sync workflows on public `main`.
- Bump package version to `0.2.1`.

### Verification
- `.venv/bin/python -m pytest tests/test_daemon_platform.py tests/test_mcp_server.py tests_b3d/test_parity_guardrail.py -q` → 30 passed
- `.venv/bin/python -m build` → built sdist and wheel