### PR TITLE
Fix release workflow permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -15,27 +15,40 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    env:
+      SKILL_SYNC_TOKEN: ${{ secrets.SKILL_SYNC_TOKEN }}
     steps:
+      - name: Skip when mirror token is unavailable
+        if: env.SKILL_SYNC_TOKEN == ''
+        run: |
+          echo "SKILL_SYNC_TOKEN is not configured; skipping public skill sync."
+
       - uses: actions/checkout@v4
+        if: env.SKILL_SYNC_TOKEN != ''
 
       - uses: actions/setup-python@v5
+        if: env.SKILL_SYNC_TOKEN != ''
         with:
           python-version: "3.12"
 
       - name: Install dependencies
+        if: env.SKILL_SYNC_TOKEN != ''
         run: pip install pyyaml
 
       - name: Generate SKILL.md
+        if: env.SKILL_SYNC_TOKEN != ''
         run: python scripts/generate_skill_md.py > /tmp/SKILL.md
 
       - name: Checkout public skill repo
+        if: env.SKILL_SYNC_TOKEN != ''
         uses: actions/checkout@v4
         with:
           repository: jdilla1277/agentcad-skill
-          token: ${{ secrets.SKILL_SYNC_TOKEN }}
+          token: ${{ env.SKILL_SYNC_TOKEN }}
           path: public-skill
 
       - name: Commit and push if changed
+        if: env.SKILL_SYNC_TOKEN != ''
         working-directory: public-skill
         run: |
           cp /tmp/SKILL.md SKILL.md


### PR DESCRIPTION
Fix the release automation discovered during the v0.2.1 publish attempt.

### Changes
- Grant `id-token: write` to the PyPI publish job so trusted publishing can request OIDC credentials.
- Make skill sync skip cleanly when `SKILL_SYNC_TOKEN` is not configured on the public repo.

### Context
The initial v0.2.1 GitHub release was created, but PyPI did not receive 0.2.1 because the publish job failed before upload.