### PR TITLE
Refresh runtime docs for build123d default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ to keep the phone from sliding. Show me a preview when you're done.
 
 ## What it does
 
-- **`agentcad run script.py --output label`** — execute a CadQuery script, produce versioned STEP file + geometric metrics (volume, dimensions, validity, face/edge counts)
+- **`agentcad run script.py --output label`** — execute a build123d or CadQuery script, produce versioned STEP file + geometric metrics (volume, dimensions, validity, face/edge counts)
 - **`agentcad run ... --preview`** — four-view PNG + turntable GIF for visual verification
 - **`agentcad run ... --render iso,front`** — high-quality PNG views
 - **`agentcad run ... --export stl,glb`** — mesh export for 3D printing or web viewers
@@ -37,14 +37,14 @@ to keep the phone from sliding. Show me a preview when you're done.
 
 ## No boilerplate
 
-Scripts need zero imports. `cq`, `show_object`, and 16 geometry helpers are pre-injected:
+Scripts need zero imports. By default, build123d primitives, `show_object`, and agentcad edit helpers are pre-injected:
 
 ```python
-box = cq.Workplane('XY').box(10, 20, 5)
+box = Box(10, 20, 5)
 show_object(box)
 ```
 
-Helpers include `translate`, `rotate`, `mirror_fuse`, `loft_sections`, `tapered_sweep`, `involute_gear_profile`, and more. Run `agentcad docs helpers` for the full list.
+CadQuery remains supported via `import cadquery as cq`, `agentcad init --runtime cadquery`, or `agentcad run --runtime cadquery`. Run `agentcad docs runtimes` for the dispatch rules.
 
 ## MCP integration
 
@@ -62,7 +62,7 @@ Add to `.mcp.json`:
 
 ## Requirements
 
-- Python 3.10–3.12 (CadQuery/OpenCascade does not support 3.13+)
+- Python 3.10–3.12 (OpenCascade bindings do not support 3.13+)
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.2.3"
+version = "0.2.4"
 description = "CLI CAD tool for AI agents. Write CadQuery scripts, get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -50,7 +50,7 @@ CHOOSING A RUNTIME
     build123d:   box = Box(10, 20, 5); show_object(box)
 
   build123d is recommended for new projects (direct primitives, Python
-  operators for booleans). cadquery is the legacy default — pick it when
+  operators for booleans). cadquery is the legacy supported runtime — pick it when
   porting existing scripts.
 
   Dispatch order: --runtime flag > script imports (`import cadquery` /
@@ -174,7 +174,7 @@ MCP INTEGRATION
 """
 
 
-def _build_briefing(runtime: str = "cadquery") -> str:
+def _build_briefing(runtime: str = "build123d") -> str:
     return _BRIEFING_TEMPLATE.replace("__RUNTIME__", runtime)
 
 
@@ -182,8 +182,8 @@ class _LoggingGroup(click.Group):
     """Click Group that auto-logs every command invocation to session.jsonl."""
 
     def format_epilog(self, ctx, formatter):
-        # Pin EXAMPLE SESSION's runtime to the project's runtime (or cadquery
-        # if no project / no runtime pin). Mirrors `agentcad docs`'s detection
+        # Pin EXAMPLE SESSION's runtime to the project's runtime or global
+        # default. Mirrors `agentcad docs`'s detection
         # so --help and docs stay in sync from a fresh agent's perspective.
         from agentcad.runners.dispatch import project_runtime, DEFAULT_RUNTIME
         rt = project_runtime() or DEFAULT_RUNTIME

--- a/src/agentcad/commands/docs.py
+++ b/src/agentcad/commands/docs.py
@@ -57,7 +57,7 @@ SECTIONS = {
     "commands": (
         "agentcad commands:\n"
         "  init    — Initialize a new agentcad project (creates agentcad.json).\n"
-        "  run     — Execute a CadQuery script, produce versioned STEP output.\n"
+        "  run     — Execute a build123d or CadQuery script, produce versioned STEP output.\n"
         "            Always produces: STEP, GLB, viewer.html, and (from v2) diff PNGs.\n"
         "            Options: --render, --export, --no-preview (skips only the 4-view composite)\n"
         "  render  — Render PNG views of an existing STEP file.\n"
@@ -487,7 +487,7 @@ SECTIONS = {
     "workflow": (
         "Typical workflow:\n"
         "  1. agentcad init --name myproject\n"
-        "  2. Write a CadQuery script (script.py) with show_object().\n"
+        "  2. Write a build123d or CadQuery script (script.py) with show_object().\n"
         "  3. agentcad run script.py --output label [--render iso] [--export stl,glb]\n"
         "  4. agentcad render v1_label/output.step --view front,top --zoom 1.5\n"
         "  5. agentcad export v1_label/output.step --format stl,glb\n"
@@ -507,7 +507,7 @@ SECTIONS = {
         '       {"agentcad": {"command": "python", "args": ["-m", "agentcad.mcp"]}}\n'
         "\n"
         "  Available tools:\n"
-        "    run       Execute a CadQuery script, produce STEP + metrics\n"
+        "    run       Execute a build123d or CadQuery script, produce STEP + metrics\n"
         "    render    Render PNG views of a STEP file\n"
         "    export    Export STEP to mesh formats (stl, glb, obj)\n"
         "    inspect   Topology report (solids, shells, faces, validity)\n"
@@ -544,7 +544,7 @@ SECTIONS = {
         "    build123d  Recommended for new projects. Direct primitives, Python\n"
         "               operators for booleans (-, +, &), better composition for\n"
         "               complex assemblies. The migration target.\n"
-        "    cadquery   Legacy default. Workplane-fluent API. Pick this if you're\n"
+        "    cadquery   Legacy supported runtime. Workplane-fluent API. Pick this if you're\n"
         "               porting existing scripts or already comfortable with it.\n"
         "\n"
         "  How dispatch works (highest precedence to lowest):\n"

--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -120,7 +120,7 @@ def _record_failure(manifest, script_path, label, version_num, error_msg, runtim
 @click.option("--preview/--no-preview", default=True, help="4-view composite PNG + per-part previews (default on, ~2-4s). The viewer.html, GLB, and diff PNGs always generate regardless — --no-preview only skips the composite render. Use it when you don't need the agent-readable PNG this iteration.")
 @click.option("--params", default=None, help="Parameter overrides as key=value,key=value.")
 @click.option("--dry-run", is_flag=True, default=False, help="Compute metrics without creating a version or disk artifacts.")
-@click.option("--runtime", default=None, type=click.Choice(["cadquery", "build123d"]), help="Force a runtime. Default: auto-detect from the script's imports; falls back to cadquery when neither library is imported.")
+@click.option("--runtime", default=None, type=click.Choice(["cadquery", "build123d"]), help="Force a runtime. Default: auto-detect from script imports, then project runtime, then build123d.")
 @click.option("--no-daemon", is_flag=True, default=False, help="Skip daemon routing for this run, even if a daemon is running. Useful for debugging.")
 @click.pass_context
 def run(ctx, script, output, render, export, preview, params, dry_run, runtime, no_daemon):

--- a/src/agentcad/commands/skill.py
+++ b/src/agentcad/commands/skill.py
@@ -11,15 +11,15 @@ SKILL_CONTENT = """\
 name: agentcad
 description: >
   CAD tool for AI agents. Use when the user asks you to design, model, or build
-  a 3D object. agentcad executes CadQuery Python scripts and produces STEP files,
-  PNG renders, mesh exports (STL/GLB/OBJ), and geometric metrics.
+  a 3D object. agentcad executes build123d or CadQuery Python scripts and
+  produces STEP files, PNG renders, mesh exports (STL/GLB/OBJ), and geometric metrics.
 compatibility: Requires Python 3.10-3.12 and agentcad installed (pip install agentcad).
 allowed-tools: Bash(agentcad:*)
 ---
 
 # agentcad — CAD tool for AI agents
 
-You have access to `agentcad`, a CLI that turns CadQuery Python scripts into
+You have access to `agentcad`, a CLI that turns build123d or CadQuery Python scripts into
 3D geometry. All output is JSON. Every command returns `"command"` and `"status"` keys.
 
 ## First-time setup
@@ -31,8 +31,9 @@ agentcad --help   # Read this — it is your complete operational briefing
 
 ## Core workflow
 
-1. **Write a script.** No imports needed — `cq`, `show_object`, and all helpers
-   are pre-injected. `show_object(result)` is required.
+1. **Write a script.** No imports needed — build123d primitives,
+   `show_object`, and agentcad edit helpers are pre-injected by default.
+   `show_object(result)` is required.
 
 2. **Dry-run first** to check metrics without consuming a version:
    ```bash
@@ -73,18 +74,22 @@ agentcad --help   # Read this — it is your complete operational briefing
 ## Script writing rules
 
 - `show_object(result)` is required — at least one call.
-- These are pre-injected (no import needed):
-  `cq`, `show_object`, `translate`, `rotate`, `mirror_fuse`, `loft_sections`,
-  `tapered_sweep`, `naca_wire`, `bbox_point`, `place_at`, `assemble`,
-  `ellipse_wire`, `spline_wire`, `polygon_wire`, `rounded_rect_wire`,
-  `elliptical_sweep`, `involute_gear_profile`
-- Helpers operate on `TopoDS_Shape`. Bridge with `.val().wrapped`:
+- These are pre-injected by default (no import needed):
+  build123d primitives like `Box`, `Cylinder`, `Sphere`, `Plane`, plus
+  `show_object`, `load_step`, `pick_face`, `pick_edge`, `fillet_edges`,
+  `chamfer_edges`, `shell_faces`, `cut_pocket`, `boss`, `split_by_plane`,
+  and `replace_face`.
+- CadQuery remains supported. Use `import cadquery as cq`, initialize with
+  `agentcad init --runtime cadquery`, or pass `--runtime cadquery`.
+- CadQuery helper paths operate on `TopoDS_Shape`. Bridge with `.val().wrapped`:
   ```python
+  import cadquery as cq
   part = cq.Workplane('XY').box(10, 20, 5).val().wrapped
   moved = translate(part, 50, 0, 0)
   ```
 - To show helper output:
   ```python
+  import cadquery as cq
   show_object(cq.Workplane('XY').newObject([cq.Shape.cast(topo_shape)]))
   ```
 - For OCP internals (`gp_Pnt`, `BRepPrimAPI`, etc.), import manually.

--- a/src/agentcad/mcp/server.py
+++ b/src/agentcad/mcp/server.py
@@ -69,10 +69,10 @@ def run(
     params: str | None = None,
     dry_run: bool = False,
 ) -> dict:
-    """Execute a CadQuery script and produce a versioned STEP file with metrics.
+    """Execute a build123d or CadQuery script and produce a versioned STEP file with metrics.
 
     Args:
-        script: Path to the CadQuery Python script.
+        script: Path to the Python CAD script.
         output: Label for this version.
         cwd: Project directory (must contain agentcad.json).
         render: Comma-separated views to render (front,right,top,iso,all).

--- a/src/agentcad/runners/dispatch.py
+++ b/src/agentcad/runners/dispatch.py
@@ -4,7 +4,7 @@ The CLI stays a single ``agentcad run`` command. Dispatch is invisible
 to users: a script that writes ``import cadquery as cq`` gets the
 CadQuery runner, one that writes ``from build123d import Box`` gets
 the build123d runner, and a script that imports neither falls back to
-the project's default runtime (or ``cadquery`` if no project mode is
+the project's default runtime (or ``build123d`` if no project mode is
 set), preserving every existing agentcad script on disk.
 
 Scripts that somehow import *both* are rejected — silently guessing
@@ -15,7 +15,7 @@ Precedence (highest to lowest):
   1. ``--runtime`` CLI flag (one-off override)
   2. Explicit script imports (``import cadquery`` / ``from build123d ...``)
   3. Project mode (``runtime`` field in ``agentcad.json``)
-  4. Global default (``cadquery``)
+  4. Global default (``build123d``)
 """
 
 from __future__ import annotations

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -30,7 +30,7 @@ def test_help_points_at_docs_for_preamble(runner):
 
 
 def test_cadquery_preamble_docs_list_helpers(runner, isolated_dir):
-    """The CadQuery preamble docs (default runtime) must list the helpers
+    """The CadQuery preamble docs must list the helpers
     that --help used to enumerate directly."""
     result = runner.invoke(cli, ["docs", "preamble", "--runtime", "cadquery"])
     content = json.loads(result.stdout)["content"]

--- a/tests/test_help_consistency.py
+++ b/tests/test_help_consistency.py
@@ -57,6 +57,7 @@ class TestHelpConsistency:
             f"docs default to {other}",
             f"{other} fallback",
             f"{other} (the legacy default)",
+            f"{other} is the legacy default",
             f"> {other} fallback",  # the "Dispatch order: ... > cadquery fallback" line
             "will flip after Phase 6",
         ]
@@ -78,6 +79,7 @@ class TestHelpConsistency:
         bad_phrasings = [
             f"Fallback: {other}",
             f"Global default: {other}",
+            f"{other}   Legacy default",
             f"the legacy default; will flip after Phase 6",
             "wins if set",
         ]


### PR DESCRIPTION
Updates README, CLI help/docs, MCP tool descriptions, and generated skill text so build123d is presented as the current default runtime while CadQuery remains supported.\n\nVerification:\n- .venv/bin/python -m pytest tests/test_help.py tests/test_help_consistency.py tests/test_docs.py tests/test_runtime_mode.py tests/test_skill.py -q\n- .venv/bin/python -m build\n\nNo PyPI or ClawHub publish has been performed.