### PR TITLE
Add promotional outreach plan

### DIFF
--- a/prd/promotional_plan.md
+++ b/prd/promotional_plan.md
@@ -1,0 +1,144 @@
+# agentcad Promotional Plan
+
+Internal launch + outreach plan. **Do not commit to the public repo** (per CLAUDE.md public-repo rules — no marketing drafts). Related: [influencers.md](influencers.md), [clawhub_publishing.md](clawhub_publishing.md).
+
+---
+
+## Events
+
+Atlanta-area venues for demoing agentcad. Target the intersection of **AI builders** (the agent angle) and **makers** (the CAD / 3D-printing angle). Lead with the live demo and the problem, not the product — "watch an agent take a spec to a manufacturable STEP file" beats "let me tell you about agentcad."
+
+### Best fit — demo-first culture (lowest self-promotion risk)
+
+| Venue | Format / cadence | Why it fits | Link |
+|---|---|---|---|
+| **AI Tinkerers Atlanta** | Monthly, ~3 hrs at Atlanta Tech Village; two sets of 5-min lightning demos + a 10-min demo slot w/ Q&A, capped at 50–60 builders. "No slides, no pitches, no fluff." | **Top pick.** An agent that drives CAD is exactly what this crowd shows up for; demoing *is* the contribution. 2026 adds a **dev-tools track for AI coding agents** (Claude Code, Cursor, Copilot) — agentcad is a natural fit. Submit as a builder demo. | https://atlanta.aitinkerers.org/ · [Meetup](https://www.meetup.com/ai-tinkerers-atlanta/) |
+| **Atlanta AI Meetups** | Short substantive talks + live demos of real projects | Same demo-first ethos; developers/hackers who are heavy AI users. Strong second venue. | https://www.meetup.com/atl-ai/ |
+| **Mond.AI @ Atlanta Tech Village** | Free weekly; "show and tell" featured slot (~9:00–9:30 AM) | Low stakes, frequent cadence — good warm-up run before a bigger room. | https://atlantatechvillage.com/events/upcoming |
+
+### Strong fit — maker crowd who actually use CAD
+
+| Venue | Format / cadence | Why it fits | Link |
+|---|---|---|---|
+| **Decatur Makers** | All-ages membership makerspace; CNC mill, Glowforge laser, multiple 3D/resin printers | Members generate the parametric models we'd agent-ify; they feel the CAD pain firsthand. Offer to *teach a short CAD-for-printing class* rather than "present." | https://www.decaturmakers.org/ |
+| **Freeside Atlanta** | Non-profit hackerspace (est. 2009), ~9,000-member Meetup; open houses 2nd & 4th Tue 7:30 PM + member-led classes | Open-house slot = low-pressure informal demo; offering a free class is the welcomed path to a real session. | https://www.freesideatlanta.org/ |
+| **The Maker Station** (Marietta / NW metro) | Active 3D-printing community; runs beginner FDM classes | If closer to the NW corridor — a CAD-for-printing session fits their teaching format. | https://www.themakerstation.com/ |
+| **Atlanta Tech Talks** | Meetup with a "Fun Hardware Tech" track (Arduino, Raspberry Pi, 3D printing, microcontrollers) | Hardware-curious devs who model real parts — a spec → printable STEP demo lands. | https://www.meetup.com/atlanta-tech-talks/ |
+
+### Startup, hardware & manufacturing crowd
+
+| Venue | Format / cadence | Why it fits | Link |
+|---|---|---|---|
+| **ATDC @ Georgia Tech** | Hardware-focused incubator in Tech Square with a design studio (3D printing); hosts founder events | Hardware founders who live in CAD; warm room for the manufacturing-output story. | https://atdc.org/ |
+| **Atlanta Startup CoFounders — Startup Oasis Pitchathon** | In-person, **3rd Thursday monthly** at ATDC | Founder pitch night — a tight live demo plays well. | https://www.meetup.com/atlanta-technology-cofounders/ |
+| **Southeast Design-2-Part Show** | Annual contract-manufacturing trade show, Cobb Galleria (last held Mar 10–11, 2026; next ~spring 2027) | Engineers sourcing 3D printing / CNC — exactly who outputs STEP files. Walk it before considering exhibiting. | https://www.d2p.com/ |
+
+### Bigger stage — once the demo is polished
+
+| Venue | Format / cadence | Why it fits | Link |
+|---|---|---|---|
+| **RenderATL** | **Aug 12–13, 2026**, downtown Atlanta; large dev conference w/ an open Call for Speakers | Big developer stage; a talk/demo here is reach once the pitch is honed. CFP is the entry point — apply early. | https://www.renderatl.com/ · [CFP](https://sessionize.com/renderatl-2026/) |
+| **Atlanta Tech Week** | City-wide annual tech festival; demo/showcase slots + side events | Once-a-year amplifier after the demo is honed on smaller stages. | https://www.atl.tech/ |
+
+### Playbook — demoing without feeling promotional
+
+- **Lead with problem + live demo**, not the product.
+- At makerspaces, **offer to teach a class** (CAD-for-3D-printing) — that's the welcomed format and gets a captive, relevant audience.
+- At AI Tinkerers / ATL AI, **submit as a builder demo** — that's literally what the slot is for, so it can't read as spam.
+- **Open-source/CLI framing** travels better: "here's a thing I built, try it" > a launch pitch.
+
+### TODO
+
+- [ ] Register on AI Tinkerers Atlanta + Meetup; grab the next monthly date / demo signup and apply for the 2026 dev-tools track.
+- [ ] Confirm Freeside open-house dates (2nd & 4th Tue 7:30 PM) and the Mond.AI weekly slot.
+- [ ] Check the RenderATL CFP deadline and decide whether to apply for the Aug 12–13 stage.
+- [ ] Identify a single flagship demo (spec → STEP) to reuse across venues — same clip as the Micro-influencers 60-sec artifact.
+- [ ] Decide first venue — recommend a Mond.AI warm-up, then AI Tinkerers.
+- Resource: Atlanta 3D-print event calendar — https://techspoatlanta.com/atlanta-3d-print-events/
+
+---
+
+## Micro-influencers
+
+**Thesis:** reach the big voices by winning the small, vibrant ones first. Target creators with small-but-active communities where we can get in people's ears/feeds naturally (YouTube, podcasts, Substack). Active matters more than big.
+
+**Targeting insight:** most "3D printing influencers" are *printer/print* people (machine reviews, print showcases) — wrong job-to-be-done; they print, they don't design from code. agentcad's "wow" only lands with people who already **design parametrically or write CAD**. That niche is small-but-vibrant by nature — exactly the thesis. Work the rings in order; Ring 1 credibility cascades up to Ring 2/3.
+
+### Ring 1 — code-CAD / AI-CAD (bullseye, start here)
+
+An agent that writes CAD code is *native* to how these people already think. Highest conversion, smallest audiences.
+
+| Target | Type | Why it fits | Link |
+|---|---|---|---|
+| **CAD + AI** | Substack (~1k subs, monthly + IRL meetups) | Hand-picked founders/researchers/engineers at the CAD–AI intersection — near-perfect audience. Pitch a guest post or meetup demo. | https://cadai.substack.com/ |
+| **The Built Future** | Substack | Wrote "Text to 3D CAD is coming: Who's building it?" — actively cataloging this exact space; we're a natural case study/subject. | https://thebuiltfuture.substack.com/p/text-to-3d-cad-is-coming-whos-building |
+| **Future Creative** (Per Magnus Skold) | Substack | Industrial design + AI-in-creativity; ships "idea → 3D print" content. Design-led audience open to AI tooling. | https://futurecreative.substack.com/ |
+| **OpenSCAD / code-CAD YouTubers** | YouTube (small, <~20k) | e.g. MakeWithTech (OpenSCAD), FreeCAD Hub, the Nov-2025 "Modeling with CODE (OpenSCAD)" creators. Viewers already accept CAD = code, so "AI writes the code" is a one-step leap. | https://makewithtech.com/ |
+| **AI-CAD startup communities** | Discord/founder circles | Zoo/Zookeeper, Adam, Spectral Labs (SGS-1). Not influencers, but where earliest evangelists cluster — be present. | https://zoo.dev/zookeeper |
+
+### Ring 2 — functional-design 3D printing channels (small, active)
+
+They model real parts (brackets, fixtures, repairs) and feel CAD slowness; AI is intriguing but not yet their native language.
+
+| Target | Type | Why it fits | Link |
+|---|---|---|---|
+| **CAD CRAFT** | YouTube | Reverse-engineers/redesigns broken machine parts in CAD then prints — functional-design ethos, modest size. | https://www.youtube.com/channel/UCWC4-hhOn5AH9XlMBdAcT_Q |
+| **Desktop Makes** | YouTube | Weekly Fusion 360 + 3D printing design tutorials. | — |
+| **Functional Print Friday** | YouTube / design site | One of the cleanest fits: functional printed parts, engineering constraints, and useful shop/project designs. Pitch a creator-specific demo that improves or recreates one of their practical parts. | https://www.fpfdesigns.com/ |
+| **thehardwareguy** | YouTube / CAD courses | CAD + CNC + electronics audience; teaches practical design workflows and should understand the value of agent-assisted parametric modeling quickly. | https://www.thehardwareguy.co.uk/ |
+| **Hoffman Engineering** | YouTube / engineering content | Mechanical engineering, software, 3D scanning, CAD, and 3D printing overlap. Good technical validator for whether agentcad produces useful geometry, not just a flashy demo. | https://www.hoffman.engineering/about/contact/ |
+| **Tech & Espresso** | YouTube / CAD community | Fusion 360, product design, 3D printing, functional parts, and a designer newsletter/community. Strong fit for "speed up common CAD workflows" positioning. | https://www.techandespresso.com/ |
+| **Makers Mashup** | YouTube / maker projects | DIY electronics + 3D printing projects; useful audience for enclosures, mounts, brackets, fixtures, and electronics housings. | https://www.makersmashup.com/about |
+| **Captain Kearn** | YouTube / livestreams | Printer repair/mods/troubleshooting and community livestreams; angle as "design the replacement or mod part live." | https://www.captainkearn.com/ |
+| **Canuck Creator** | YouTube / livestreams | 3D printing livestreams, CAD/slicer topics, printer builds, and sponsor-friendly format. Offer a live or semi-live prompt-to-printable-file workflow. | https://socialblade.com/youtube/channel/UCmV40QWkVeRs_nAvEOE_P-g |
+| **3DPrintSOS** | YouTube | Troubleshooting-heavy 3D printing channel. Less CAD-native, but useful for "quick fixes, replacement parts, and printer mods" demos. | https://vling.net/en/channel/UC1MsDQaRANzwISN8cHJ1VmQ |
+| **Teaching Tech** | YouTube | Industrial designer/teacher; CAD + 3D modeling; known for honest tutorials. | — |
+| **Project Build Stuff** | YouTube | High-school engineering teacher; CAD + CNC + 3D printing builds. | — |
+| **Make Anything** | YouTube | Classic problem → sketch → CAD → print → iterate workflow (design-first). | — |
+| **Peter Grande** (~21k) | YouTube | CAD for custom jewelry — niche but a designer audience. | — |
+
+### Ring 3 — podcasts (interview format = natural live demo)
+
+| Target | Type | Why it fits | Link |
+|---|---|---|---|
+| **The Infill Podcast** (Jonathan Levi) | Podcast (~80 eps, active 2026) | Weekly maker/industry interviews — interview slot = demo agentcad live. | https://podcasts.apple.com/us/podcast/the-infill-podcast-the-place-for-3d-printing/id1676508097 |
+| **3D Printing Today** (Andy Cohen & Whitney Potter) | Podcast (long-running) | Design/capture-professional hosts who'd appreciate a CAD-automation angle. | https://threedprintingtoday.libsyn.com/ |
+| **Whatcha Makin'** | Podcast | Broad maker show — top-of-funnel reach. | — |
+
+### Playbook — outreach (the move matters as much as the list)
+
+- **Lead with a 60-second artifact, not a pitch** — screen capture of an agent going one-line prompt → CadQuery/build123d script → printable STEP. Code-CAD people get it instantly.
+- **Give, don't ask** — offer a free "design this live on your show" segment or a guest tutorial. We're handing them content, not requesting a favor.
+- **Start with Ring 1 even though it's smallest** — CadQuery/OpenSCAD creators vouching for it cascades credibility upward (the "small reaches big" thesis, executed in order).
+- **Open-source/CLI framing travels best** — "here's a thing I built, try it" > a launch pitch.
+- **Customize every Ring 2 demo to a recent project** — "let's recreate/improve this exact bracket/enclosure/mount from your channel" will land better than generic AI-CAD positioning.
+
+### Creator outreach template
+
+Subject: Demo idea: AI-assisted CAD for functional 3D printed parts
+
+Hi [Name],
+
+I'm building agentcad, an AI CAD workflow for going from a part idea to printable geometry faster.
+
+I thought it might fit your audience because you cover functional prints, CAD, and maker workflows. I'd love to give you a private demo using a real part from your shop or channel instead of a canned example.
+
+Possible demo ideas:
+- design a replacement bracket from constraints
+- modify an existing part for printability
+- generate a parametric enclosure or mount
+- iterate clearances, holes, ribs, and fillets for FDM
+
+No pressure to cover it. I'm mainly looking for sharp feedback from creators who understand where CAD slows makers down.
+
+Would you be open to a 20-minute demo?
+
+### TODO
+
+- [ ] Spot-check top 5 candidates' *current* activity + subscriber counts before outreach (counts/active-status not independently verified at capture).
+- [ ] Find direct contact/channel URLs for the dash-marked rows (Desktop Makes, Teaching Tech, Project Build Stuff, Make Anything, Peter Grande, Whatcha Makin').
+- [ ] Pick first Ring 2 outreach batch: Functional Print Friday, thehardwareguy, Hoffman Engineering, Desktop Makes, Tech & Espresso.
+- [ ] For each Ring 2 target, identify one recent project to use as the custom demo prompt.
+- [ ] Cut the flagship 60-sec spec → STEP demo clip (shared with Events flagship demo).
+- [ ] Draft the Ring 1 outreach note (guest post / meetup demo for CAD + AI; case-study angle for The Built Future).
+- [ ] Build a simple outreach tracker (name, ring, audience, channel, contact, status).


### PR DESCRIPTION
## Summary
- Add internal promotional plan with event, micro-influencer, and podcast outreach targets
- Fold 3D printing creator outreach into the micro-influencer rings
- Add a reusable creator outreach template and follow-up TODOs

## Testing
- Not run; docs/plan-only change