### PR TITLE
Clarify public repo identity for agents

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,21 @@
 
 agentcad is a local CLI and MCP server for AI-agent CAD workflows.
 
+## Repo Identity
+
+This checkout is the **public** `jdilla1277/agentcad` repo. It is for
+externally safe package code, public docs, and examples.
+
+Do **not** open PRs here for internal planning material: PRDs, roadmap notes,
+marketing drafts, promotional plans, feedback logs, launch notes, private
+operational context, or anything that should not be public.
+
+If the user asks for internal planning, promotion work, or website work for
+`agentcad.dev`, use the internal repo at
+`/Users/jamesdillard/Documents/mountain-climber-2/agentcad-internal`
+(`jdilla1277/agentcad-internal`) instead. Before creating any PR, run
+`git remote -v` and confirm whether the target repo is public or internal.
+
 ## Development
 
 Use Python 3.10-3.12. CadQuery/OpenCascade does not support Python 3.13+.


### PR DESCRIPTION
This makes the public agent instructions explicit about what belongs in the public repo. It also points internal planning, promotion, and agentcad.dev website work to the internal repository before agents create PRs.

## Summary
- Add a Repo Identity section to the public repo instructions
- Route PRDs, marketing, promotional plans, feedback logs, launch notes, and agentcad.dev work to agentcad-internal
- Tell agents to verify the remote before creating PRs

## Testing
- Not run; docs/instruction-only change