### PR TITLE
Add Product Hunt badge and demo video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,14 @@ Your agent writes CadQuery or build123d Python scripts. agentcad handles executi
 
 agentcad is open source under the Apache License 2.0. It runs locally and requires no signup.
 
+[![Featured on Product Hunt](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1165633&theme=light)](https://www.producthunt.com/products/agentcad?utm_source=badge-featured&utm_medium=badge&utm_campaign=badge-agentcad)
+
+## Demo
+
+[![Watch a coding agent design in agentcad](https://img.youtube.com/vi/Zsn31-IilWM/maxresdefault.jpg)](https://www.youtube.com/watch?v=Zsn31-IilWM)
+
+A coding agent designing in agentcad, live. See more at [agentcad.dev](https://agentcad.dev).
+
 ## Quick start
 
 Install agentcad, then paste this into Claude Code, Cursor, or any coding agent:


### PR DESCRIPTION
README visitors now see the Product Hunt launch and a one-click demo right at the top — an official "Featured on Product Hunt" badge linking to the listing, and a clickable thumbnail that opens the live demo on YouTube. Before, neither the launch nor the demo video was discoverable from the repo at all.

## What changed
- **Product Hunt badge** added under the intro, linking to the agentcad listing.
- **Demo section** with a clickable video thumbnail. GitHub-flavored markdown can't embed a live YouTube player (no iframes), so a thumbnail that links out to the video is the standard pattern; it also points to agentcad.dev for more.

## Notes
- Both image URLs (PH `featured.svg`, YouTube `maxresdefault.jpg`) were verified to return 200 before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)