### PR TITLE
Pin build123d <0.11 to fix broken default runtime on clean install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,16 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
-dependencies = ["click>=8.0", "cadquery>=2.0", "build123d>=0.9"]
+dependencies = [
+    "click>=8.0",
+    "cadquery>=2.0",
+    # Cap below 0.11: build123d 0.11 switched to cadquery-ocp-novtk (OCP 7.9),
+    # which collides with the cadquery-ocp 7.8 that `cadquery` pins. Two OCP
+    # builds on one path means `import build123d` dies with
+    # "TopoDS has no attribute 'Vertex'", breaking the default runtime on a
+    # clean install. 0.10.x shares cadquery's cadquery-ocp 7.8 — no conflict.
+    "build123d>=0.10,<0.11",
+]
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]


### PR DESCRIPTION
## Problem

A clean `pip install agentcad` leaves the **default runtime (build123d) unable to import**:

```
AttributeError: type object 'OCP...TopoDS' has no attribute 'Vertex'
```

`build123d` 0.11 switched its OCP dependency to `cadquery-ocp-novtk` (OCP 7.9), while `cadquery` pins `cadquery-ocp` 7.8. Both distributions provide the top-level `OCP` package, so installing them together puts two incompatible OCP builds on one import path. `import build123d` then dies before any script runs — and since build123d is the default runtime (and the one the docs recommend for new projects), a new user following the README hits a hard error on their first `agentcad run`.

## Fix

Pin `build123d>=0.10,<0.11`. 0.10.x depends on the same `cadquery-ocp<7.9` that `cadquery` uses, so the two share a single OCP install and the runtime works. One-line dependency change (reformatted to a multiline list with an explanatory comment).

## Verification

- With `build123d==0.10.0`, the build123d runtime runs a multi-part involute spur-gear assembly end-to-end — `is_valid: true` on every part and the compound.
- `pip install --dry-run` resolves to `build123d 0.10.0` + `cadquery-ocp 7.8` only — **no `cadquery-ocp-novtk`, no 7.9** on the path.

## Why CI missed it

`Smoke` only runs `pytest --collect-only` plus an OCP-free guardrail; it never imports build123d/OCP for real. A follow-up worth considering: a CI step that actually imports the default runtime (or runs one trivial `agentcad run` on each runtime) would have caught this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)