### PR TITLE
Point subscribe/feedback at agentcad.dev

### DIFF
--- a/src/agentcad/commands/feedback.py
+++ b/src/agentcad/commands/feedback.py
@@ -12,7 +12,7 @@ import click
 from agentcad.session_log import SessionLogger
 
 
-_DEFAULT_FEEDBACK_URL = "https://agentcad-site-five.vercel.app/api/feedback"
+_DEFAULT_FEEDBACK_URL = "https://agentcad.dev/api/feedback"
 
 
 def _resolve_feedback_url() -> str:

--- a/src/agentcad/commands/subscribe.py
+++ b/src/agentcad/commands/subscribe.py
@@ -9,6 +9,7 @@ so the address isn't added to the list until the user clicks the link.
 """
 
 import json
+import os
 import re
 import sys
 from urllib.error import URLError
@@ -19,8 +20,12 @@ import click
 from agentcad.session_log import _environment_info
 
 
-_SUBSCRIBE_URL = "https://agentcad-site-five.vercel.app/api/subscribe"
+_DEFAULT_SUBSCRIBE_URL = "https://agentcad.dev/api/subscribe"
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def _resolve_subscribe_url() -> str:
+    return os.environ.get("AGENTCAD_SUBSCRIBE_URL") or _DEFAULT_SUBSCRIBE_URL
 
 
 def _send_remote(payload: dict) -> tuple[str | None, dict | None]:
@@ -31,7 +36,7 @@ def _send_remote(payload: dict) -> tuple[str | None, dict | None]:
     try:
         data = json.dumps(payload).encode("utf-8")
         req = Request(
-            _SUBSCRIBE_URL,
+            _resolve_subscribe_url(),
             data=data,
             headers={"Content-Type": "application/json"},
             method="POST",
@@ -59,6 +64,10 @@ def subscribe(email):
     Submits the address to the agentcad signup endpoint. The user will
     receive a confirmation email; their address is added to the list
     only after they click the link.
+
+    \b
+    Set AGENTCAD_SUBSCRIBE_URL to point at a non-default endpoint (preview
+    deploys, self-hosted instances). Defaults to the production endpoint.
     """
     normalised = email.strip().lower()
     if not _EMAIL_RE.match(normalised) or len(normalised) > 254:


### PR DESCRIPTION
## What

Both the CLI `subscribe` command and the `feedback` command defaulted to the `agentcad-site-five.vercel.app` alias. This points both at the production domain `agentcad.dev`, and adds an `AGENTCAD_SUBSCRIBE_URL` env override to `subscribe` mirroring the `AGENTCAD_FEEDBACK_URL` override `feedback` already has.

## Why

The confirmation email's confirm link is derived from the host that receives the request. Signing up via the Vercel alias sent users a raw `vercel.app` confirm link — unbranded and lower-trust on a double opt-in. Hitting `agentcad.dev` produces a clean, branded `agentcad.dev/api/subscribe/confirm?...` link.

## Verification

- `POST https://agentcad.dev/api/subscribe` → `200 {"status":"pending_confirmation"}`, confirmation email delivered from `updates@agentcad.dev` with an `agentcad.dev` confirm link (tested live with a real address).
- `POST https://agentcad.dev/api/feedback` (no auth key) → `401` — route present and authenticating; the CLI authenticates via the `x-agentcad-key` header.

Note: the subscribe test suite stubs `_send_remote`, so these URL-default changes don't affect existing tests. No dev environment is provisioned in this workspace, so the suite was not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)