### PR TITLE
Document sub-agent friction checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,19 @@ pytest
 - Keep error messages concise and actionable for coding agents.
 - Prefer local, deterministic workflows over hosted dependencies.
 
+## Validation
+
+For changes to agent-facing contracts, CLI workflows, docs/help output, viewer
+behavior, or app-like user flows, run a narrow sub-agent friction check before
+opening or finalizing the PR. Ask the sub-agent to behave like a fresh agent:
+read the docs, use the feature end-to-end in a scratch project, and report
+confusing behavior or mismatches between docs and reality.
+
+Keep friction artifacts under `.context/` unless they are intentional public
+fixtures. When validating unmerged CLI behavior, avoid stale installed code and
+stale daemons: use the current checkout (`PYTHONPATH=src` or editable install)
+and pass `--no-daemon` for command behavior checks.
+
 ## Public Repo Rules
 
 - Do not add internal PRDs, roadmap notes, marketing drafts, feedback logs, secrets, or private operational context.


### PR DESCRIPTION
## Summary
- document when to run narrow sub-agent friction checks for agent-facing contracts, CLI workflows, docs/help output, viewer behavior, and app-like flows
- specify that friction artifacts should stay under `.context/` unless intentionally public
- call out the local-validation footgun found during M64: use current checkout code and `--no-daemon` when checking unmerged CLI behavior

## Validation
- docs-only change; no test run needed

## Context
- Follow-up from #15 and its sub-agent friction run.
