### PR TITLE
Document specs and measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ agentcad is open source under the Apache License 2.0. It runs locally and requir
 
 A coding agent designing in agentcad, live. See more at [agentcad.dev](https://agentcad.dev).
 
+> [!NOTE]
+> **New: specs and measurements**
+> - `agentcad measure` reads the actual STEP geometry: dimensions, cylindrical feature buckets, diameters, and counts.
+> - `agentcad check-spec` compares the model against explicit feature requirements before the agent says it is done.
+> - `agentcad view --spec spec.json` opens a Spec check review mode so humans can inspect pass/fail results in the browser.
+
 ## Quick start
 
 Install agentcad, then paste this into Claude Code, Cursor, or any coding agent:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ agentcad is open source under the Apache License 2.0. It runs locally and requir
 
 A coding agent designing in agentcad, live. See more at [agentcad.dev](https://agentcad.dev).
 
-> [!NOTE]
 > **New: specs and measurements**
 > - `agentcad measure` reads the actual STEP geometry: dimensions, cylindrical feature buckets, diameters, and counts.
 > - `agentcad check-spec` compares the model against explicit feature requirements before the agent says it is done.

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -174,6 +174,15 @@ METRICS (in every successful run response)
   before rendering. Use 'agentcad diff' to compare metrics across versions.
 
 \b
+SPEC AND MEASUREMENT CHECKS
+  Visual renders are not enough for dimensional work. When the prompt has
+  explicit holes, bores, diameters, counts, or overall dimensions:
+    1. Run normally and inspect the generated STEP.
+    2. Use `agentcad measure` to read dimensions and feature buckets from CAD.
+    3. Use `agentcad check-spec` when you have an explicit JSON checklist.
+    4. Revise before marking the model done if measurements or spec rows fail.
+
+\b
 DEBUGGING
   Geometry wrong? Check metrics first — volume and dimensions catch most issues.
   $ agentcad run script.py --output test --dry-run        # metrics, no disk artifacts

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -83,6 +83,16 @@ def test_help_mentions_metrics(runner):
     assert "volume" in output
 
 
+def test_help_mentions_spec_and_measurement_checks(runner):
+    result = runner.invoke(cli, ["--help"])
+    output = result.output
+    assert "SPEC AND MEASUREMENT CHECKS" in output
+    assert "explicit holes, bores, diameters, counts" in output
+    assert "agentcad measure" in output
+    assert "agentcad check-spec" in output
+    assert "Revise before marking the model done" in output
+
+
 def test_help_mentions_parametric(runner):
     result = runner.invoke(cli, ["--help"])
     output = result.output


### PR DESCRIPTION
## Summary
- add a small README callout for the new specs and measurements feature
- add a concise specs/measurements section to the top-level CLI help
- add help coverage so the workflow stays visible to agents

## Verification
- .venv/bin/python -m pytest tests/test_help.py -q