### PR TITLE
Release v0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.2.4"
+version = "0.3.0"
 description = "CLI CAD tool for AI agents. Write CadQuery scripts, get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
## Summary
- bump agentcad package version to 0.3.0 for the M65 specs and measurements release

## Verification
- .venv/bin/python -m pytest -q — 986 passed, 1 skipped
- uvx --from build python -m build — built sdist and wheel
- verified wheel metadata reports agentcad 0.3.0
- verified sdist pyproject contains version = "0.3.0"