### PR TITLE
Fix measure bbox inflation on NURBS STEP geometry (#28)

### DIFF
--- a/src/agentcad/metrics.py
+++ b/src/agentcad/metrics.py
@@ -3,6 +3,7 @@
 from OCP.Bnd import Bnd_Box
 from OCP.BRepBndLib import BRepBndLib
 from OCP.BRepCheck import BRepCheck_Analyzer
+from OCP.BRepTools import BRepTools
 from OCP.BRepGProp import BRepGProp
 from OCP.GProp import GProp_GProps
 from OCP.TopAbs import TopAbs_EDGE, TopAbs_FACE, TopAbs_SHELL, TopAbs_WIRE
@@ -17,9 +18,22 @@ def compute_metrics(topo_shape):
     Returns a JSON-serializable dict with bounding_box, dimensions, volume,
     surface_area, center_of_mass, face_count, edge_count, and is_valid.
     """
-    # Bounding box
+    # Bounding box.
+    #
+    # Use AddOptimal_s, not Add_s. Add_s derives each face/edge bound from the
+    # *poles* (control points) of its B-spline/NURBS geometry, which for
+    # rational curves and swept/lofted surfaces lie well outside the actual
+    # trimmed geometry. STEP exporters routinely emit circles, cylinders, and
+    # blade surfaces as NURBS, so Add_s can inflate `dimensions` far past the
+    # real envelope (CADGenBench 203 impeller: 586.7 reported vs 360 real).
+    # AddOptimal_s computes a tight box from the trimmed geometry and matches
+    # build123d's `bounding_box()` (which is what produced the correct 360
+    # envelope in that benchmark). Clean_s first to drop any cached
+    # triangulation that AddOptimal would otherwise prefer over the exact
+    # geometry — same sequence build123d uses.
+    BRepTools.Clean_s(topo_shape)
     bbox = Bnd_Box()
-    BRepBndLib.Add_s(topo_shape, bbox)
+    BRepBndLib.AddOptimal_s(topo_shape, bbox)
     xmin, ymin, zmin, xmax, ymax, zmax = bbox.Get()
 
     bb = {

--- a/src/agentcad/topo_ids.py
+++ b/src/agentcad/topo_ids.py
@@ -385,9 +385,17 @@ def _edge_geometry(edge):
 def _bbox(shape) -> dict:
     from OCP.Bnd import Bnd_Box
     from OCP.BRepBndLib import BRepBndLib
+    from OCP.BRepTools import BRepTools
 
+    # AddOptimal_s, not Add_s — Add_s reads B-spline/NURBS bounds off the
+    # control-point poles, which sit outside the trimmed geometry and inflate
+    # the box (see metrics.compute_metrics for the full rationale). Keeping
+    # per-solid/per-face bboxes here on the same tight basis as the top-level
+    # `metrics.dimensions` avoids `measure --features` / `inspect` reporting a
+    # per-body envelope larger than the whole-part one on NURBS geometry.
+    BRepTools.Clean_s(shape)
     box = Bnd_Box()
-    BRepBndLib.Add_s(shape, box)
+    BRepBndLib.AddOptimal_s(shape, box)
     xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
     return {
         "x": [_round(xmin), _round(xmax)],

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -160,3 +160,70 @@ class TestNegativeVolumeWarning:
         reversed_shape = box.Reversed()
         m = compute_metrics(reversed_shape)
         assert any("winding" in w.lower() for w in m["warnings"])
+
+
+def _make_bspline_circle_prism(radius=180.0, height=134.0):
+    """Extruded solid whose profile circle is stored as a rational B-spline.
+
+    STEP exporters routinely emit circles/cylinders and swept blade surfaces
+    as NURBS rather than analytic geometry. The poles (control points) of a
+    rational B-spline circle lie *outside* the curve, so BRepBndLib.Add_s
+    over-reports the envelope. AddOptimal_s (what compute_metrics uses)
+    computes a tight box. Mirrors CADGenBench sample 203 (issue #28), where
+    the raw-pole bbox read 586.7 while the true impeller envelope was ~360.
+    """
+    from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt, gp_Vec
+    from OCP.Geom import Geom_Circle
+    from OCP.GeomConvert import GeomConvert
+    from OCP.BRepBuilderAPI import (
+        BRepBuilderAPI_MakeEdge,
+        BRepBuilderAPI_MakeFace,
+        BRepBuilderAPI_MakeWire,
+    )
+    from OCP.BRepPrimAPI import BRepPrimAPI_MakePrism
+
+    circ = Geom_Circle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), radius)
+    bspline = GeomConvert.CurveToBSplineCurve_s(circ)
+    edge = BRepBuilderAPI_MakeEdge(bspline).Edge()
+    wire = BRepBuilderAPI_MakeWire(edge).Wire()
+    face = BRepBuilderAPI_MakeFace(wire, True).Face()
+    return BRepPrimAPI_MakePrism(face, gp_Vec(0, 0, height)).Shape()
+
+
+class TestBSplineBBoxNotInflatedByPoles:
+    """Regression for issue #28: dimensions must reflect the trimmed body
+    envelope, not the inflated control-point (pole) extents of NURBS geometry."""
+
+    def test_dimensions_match_true_envelope(self):
+        shape = _make_bspline_circle_prism(radius=180.0, height=134.0)
+        dims = compute_metrics(shape)["dimensions"]
+        # True diameter is 360; raw Add_s reports ~397 x ~435 from the poles.
+        assert dims["x"] == pytest.approx(360.0, abs=0.5)
+        assert dims["y"] == pytest.approx(360.0, abs=0.5)
+        assert dims["z"] == pytest.approx(134.0, abs=0.5)
+
+    def test_not_inflated_by_poles(self):
+        """Guard against a regression back to BRepBndLib.Add_s, which would
+        report the pole envelope (~397 x ~435) instead of ~360 x 360."""
+        shape = _make_bspline_circle_prism(radius=180.0, height=134.0)
+        dims = compute_metrics(shape)["dimensions"]
+        assert dims["x"] < 370.0
+        assert dims["y"] < 370.0
+
+
+class TestPerSolidBBoxNotInflatedByPoles:
+    """Regression for issue #28: the per-solid bbox in `measure --features`
+    and `inspect` (topo_ids._bbox) must use the same tight basis as the
+    top-level dimensions — not the inflated NURBS pole extents."""
+
+    def test_solid_entry_bbox_is_tight(self):
+        from agentcad import topo_ids
+
+        shape = _make_bspline_circle_prism(radius=180.0, height=134.0)
+        entry = topo_ids.solid_entries(shape)[0]
+        bb = entry["bbox"]
+        # True radius 180 → [-180, 180]; raw Add_s would push past ±198.
+        assert bb["x"][0] == pytest.approx(-180.0, abs=0.5)
+        assert bb["x"][1] == pytest.approx(180.0, abs=0.5)
+        assert bb["y"][0] == pytest.approx(-180.0, abs=0.5)
+        assert bb["y"][1] == pytest.approx(180.0, abs=0.5)


### PR DESCRIPTION
Closes #28.

## Root cause

`compute_metrics()` computed the bounding box with `BRepBndLib.Add_s`. That routine derives each face/edge bound from the **poles (control points)** of its B-spline/NURBS geometry. For rational curves and swept/lofted surfaces the poles sit *outside* the trimmed geometry, so the box is over-reported.

STEP exporters routinely store circles, cylinders, and blade surfaces as NURBS, so `metrics.dimensions` inflated on exactly the kind of part agents trust it on. On CADGenBench sample `203` (impeller) it read `586.7` vs the real ~`360` envelope, which sent editing agents down oversized/incorrect attempts.

The issue's free-edge hypothesis was ruled out: build123d reported `360` over the *same* topology (free edges and all), so the inflation is the pole overshoot, not stray geometry — and `AddOptimal_s` resolves it fully.

## Fix

Switch to `BRepBndLib.AddOptimal_s` (preceded by `BRepTools.Clean_s` to drop any cached triangulation) — a tight box over the trimmed geometry. This is the exact sequence `build123d`'s `bounding_box()` uses, i.e. the path that produced the correct `360` in the benchmark, so `measure` now agrees with the runtime loader.

Applied in two places, both feeding agent-facing `measure` output:
- `metrics.compute_metrics` → top-level `metrics.dimensions` / `bounding_box`.
- `topo_ids._bbox` → the per-solid / per-face `bbox` in `measure --features` and `inspect`. Without this, a per-body envelope could read *larger* than the whole-part one on the same NURBS part.

## Reproduction

A 360-diameter profile stored as a rational B-spline circle, extruded 134mm (matching the issue's Z):

| | x | y | z |
|---|---|---|---|
| true envelope | 360 | 360 | 134 |
| `Add_s` (old) | 397.4 | 434.6 | 134 |
| `AddOptimal_s` (this PR) | 360.0 | 360.0 | 134 |

## Verification

- Reproducer now reports `360 x 360 x 134`; per-solid bbox is tight too.
- Analytic-surface fixtures (`cadgenbench_101`, `pump_manifold`) unchanged, and `measure` now matches build123d's `bounding_box()` to 4 decimals on both.
- New regression tests cover both the top-level dimensions and the per-solid bbox.
- Full suite: **977 passed, 1 skipped** (only `test_mcp_server.py` excluded locally — `mcp` extra not installed).
- Sub-agent friction check (per CLAUDE.md, `measure` is an agent-facing contract): no docs/help text describes the old raw-bbox behavior; verdict SHIP.

## Out of scope (noted)

`helpers.bbox_point` still uses `Add_s`, but it's a script-side construction/placement helper (`place_at`, assembly), not `measure` output — tightening it would change where geometry lands, a separate behavioral call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)