### PR TITLE
Limit verbose feature output

### DIFF
--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -122,15 +122,16 @@ COMMANDS
     Export STEP to mesh formats. GLB auto-colors individual solids.
 
 \b
-  agentcad inspect STEP
+  agentcad inspect STEP [--ids|--summary] [--limit N|--no-limit]
     Topology report: solid_count, shell_count, shells (open/closed + face
     count per shell), face_count, face_orientations (forward/reversed),
-    edge_count, free_edge_count, is_valid.
+    edge_count, free_edge_count, is_valid. --ids is capped by default.
 
 \b
-  agentcad measure STEP [--features]
+  agentcad measure STEP [--features] [--cylinders-only] [--limit N|--no-limit]
     Dimensional report: overall metrics plus compact feature measurements
     (edge lengths, face areas, circular/cylindrical radii and diameters).
+    Full feature lists are capped by default; use --no-limit only when needed.
 
 \b
   agentcad check-spec STEP SPEC.json

--- a/src/agentcad/commands/docs.py
+++ b/src/agentcad/commands/docs.py
@@ -63,6 +63,7 @@ SECTIONS = {
         "  render  — Render PNG views of an existing STEP file.\n"
         "  export  — Export an existing STEP file to mesh formats (STL, GLB).\n"
         "  measure — Measure overall dimensions and feature sizes in STEP/BREP files.\n"
+        "            Full feature output is capped by default; use --no-limit explicitly.\n"
         "  check-spec\n"
         "          — Compare measured cylindrical features against an explicit JSON spec.\n"
         "  parts   — List/show parts captured for a version snapshot, or generate\n"
@@ -73,6 +74,7 @@ SECTIONS = {
         "  docs    — Show this documentation.\n"
         "  diff    — Compare two versions of a model.\n"
         "  inspect — Inspect STEP file topology (shells, faces, edges).\n"
+        "            --ids output is capped by default; use --no-limit explicitly.\n"
     ),
     "render": (
         "Rendering:\n"
@@ -238,7 +240,13 @@ SECTIONS = {
         "    agentcad measure v1_label/output.step --features\n"
         "    Adds features.solids[], features.faces[], features.edges[]. Use this\n"
         "    when you need exact face areas, face centroids/normals/bboxes, or\n"
-        "    individual edge lengths/endpoints.\n"
+        "    individual edge lengths/endpoints. Lists are capped at 100 records\n"
+        "    by default with truncation metadata. Use --limit N for a larger slice\n"
+        "    or --no-limit only when you truly need the complete JSON payload.\n"
+        "\n"
+        "  Cylinder-focused queries for large parts:\n"
+        "    agentcad measure v1_label/output.step --cylinders-only\n"
+        "    agentcad measure v1_label/output.step --cylinders-only --diameter 12 --axis +z\n"
         "\n"
         "  Relationship to inspect:\n"
         "    measure answers dimensional questions. inspect answers topology and\n"
@@ -499,7 +507,7 @@ SECTIONS = {
     ),
     "inspect": (
         "Inspecting shape topology:\n"
-        "  agentcad inspect <step_file>\n"
+        "  agentcad inspect <step_file> [--ids|--summary] [--limit N|--no-limit]\n"
         "\n"
         "  Reports the internal topology of a STEP file:\n"
         "    solid_count      Number of solid bodies\n"
@@ -518,6 +526,13 @@ SECTIONS = {
         "\n"
         "  For dimensional questions, run:\n"
         "    agentcad measure <step_file>\n"
+        "\n"
+        "  Addressable IDs:\n"
+        "    agentcad inspect <step_file> --ids\n"
+        "    Emits solids[], faces[], and edges[] for targeted edits. Lists are\n"
+        "    capped at 100 records by default with truncation metadata. Use\n"
+        "    --limit N for a larger slice or --no-limit only when you need every\n"
+        "    face and edge in the JSON response.\n"
     ),
     "daemon": (
         "Daemon (auto-managed background worker):\n"

--- a/src/agentcad/commands/inspect_cmd.py
+++ b/src/agentcad/commands/inspect_cmd.py
@@ -11,6 +11,8 @@ from agentcad.commands._daemon_routing import (
 )
 from agentcad.native_io import silence_native_stdout
 
+DEFAULT_ID_LIMIT = 100
+
 
 @click.command("inspect")
 @click.argument("file")
@@ -27,8 +29,21 @@ from agentcad.native_io import silence_native_stdout
          "alternative to --ids for parts where the per-feature payload "
          "would blow the context budget. Combine with --ids for both.",
 )
+@click.option(
+    "--limit",
+    "id_limit",
+    type=click.IntRange(min=1),
+    default=DEFAULT_ID_LIMIT,
+    show_default=True,
+    help="Maximum records per --ids list, and maximum IDs per summary cluster.",
+)
+@click.option(
+    "--no-limit",
+    is_flag=True,
+    help="Return complete --ids and summary ID lists. Can be very large.",
+)
 @click.option("--no-daemon", is_flag=True, default=False, help="Skip daemon routing for this run, even if a daemon is running. Useful for debugging.")
-def inspect_cmd(file, with_ids, with_summary, no_daemon):
+def inspect_cmd(file, with_ids, with_summary, id_limit, no_limit, no_daemon):
     """Inspect any file. STEP/BREP get a full topology report; other formats
     get a structured 'recognized but not editable here' response. Never throws."""
     # Try routing through daemon. Exits before returning if reachable.
@@ -37,6 +52,10 @@ def inspect_cmd(file, with_ids, with_summary, no_daemon):
         argv.append("--ids")
     if with_summary:
         argv.append("--summary")
+    if id_limit != DEFAULT_ID_LIMIT:
+        argv.extend(["--limit", str(id_limit)])
+    if no_limit:
+        argv.append("--no-limit")
     maybe_route_through_daemon(argv, no_daemon=no_daemon)
 
     file_path = Path(file)
@@ -149,7 +168,13 @@ def inspect_cmd(file, with_ids, with_summary, no_daemon):
         return
 
     if category == file_detect.TIER0_BREP:
-        _inspect_tier0(str(file_path.resolve()), detection, with_ids=with_ids, with_summary=with_summary)
+        _inspect_tier0(
+            str(file_path.resolve()),
+            detection,
+            with_ids=with_ids,
+            with_summary=with_summary,
+            id_limit=None if no_limit else id_limit,
+        )
         # Fork off the warm process as the daemon — only the Tier 0 path
         # paid the OCP cost worth keeping around. Idempotent on its own.
         maybe_spawn_daemon_for_next_run(no_daemon=no_daemon)
@@ -195,7 +220,14 @@ def _emit_malformed(file: str, detection: dict) -> None:
     }, exit_code=1)
 
 
-def _inspect_tier0(file_path: str, detection: dict, *, with_ids: bool = False, with_summary: bool = False) -> None:
+def _inspect_tier0(
+    file_path: str,
+    detection: dict,
+    *,
+    with_ids: bool = False,
+    with_summary: bool = False,
+    id_limit: int | None = DEFAULT_ID_LIMIT,
+) -> None:
     """Full topology report for STEP/BREP files. OCCT failures are caught and
     surfaced as malformed — never as a stack trace, never as a leaked native
     diagnostic on stdout."""
@@ -229,12 +261,27 @@ def _inspect_tier0(file_path: str, detection: dict, *, with_ids: bool = False, w
 
     if with_ids or with_summary:
         from agentcad import topo_ids
+        truncations = []
         if with_ids:
-            payload["solids"] = topo_ids.solid_entries(topo_shape)
-            payload["faces"] = topo_ids.face_entries(topo_shape)
-            payload["edges"] = topo_ids.edge_entries(topo_shape)
+            counts = topo_ids.topology_counts(topo_shape)
+            payload["solids"] = topo_ids.solid_entries(topo_shape, limit=id_limit)
+            payload["faces"] = topo_ids.face_entries(topo_shape, limit=id_limit)
+            payload["edges"] = topo_ids.edge_entries(topo_shape, limit=id_limit)
+            truncations.extend(_list_truncations(
+                counts,
+                {
+                    "solids": len(payload["solids"]),
+                    "faces": len(payload["faces"]),
+                    "edges": len(payload["edges"]),
+                },
+                id_limit,
+            ))
         if with_summary:
-            payload["summary"] = topo_ids.summary_entries(topo_shape)
+            payload["summary"] = topo_ids.summary_entries(
+                topo_shape,
+                id_limit=id_limit,
+            )
+            truncations.extend(_summary_truncations(payload["summary"]))
         # When the agent has IDs (or summary IDs), the most-likely next
         # action shifts: they're here because they want to write an edit
         # script that targets specific features. Point them at the
@@ -244,6 +291,17 @@ def _inspect_tier0(file_path: str, detection: dict, *, with_ids: bool = False, w
             "use pick_face(base, ID) / pick_edge(base, ID) in your edit script — "
             "see `agentcad docs editing`",
         ]
+        if truncations:
+            payload["truncation"] = {
+                "limited": True,
+                "limit": id_limit,
+                "fields": truncations,
+                "recommended_commands": _recommended_limit_commands(
+                    file_path,
+                    with_ids=with_ids,
+                    with_summary=with_summary,
+                ),
+            }
 
     notes = _compute_notes(payload)
     if with_ids or with_summary:
@@ -261,6 +319,63 @@ def _inspect_tier0(file_path: str, detection: dict, *, with_ids: bool = False, w
         payload["notes"] = notes
 
     _emit(payload, exit_code=0)
+
+
+def _list_truncations(
+    totals: dict,
+    returned: dict,
+    limit: int | None,
+) -> list[dict]:
+    if limit is None:
+        return []
+    fields = []
+    for name, total in totals.items():
+        count = returned[name]
+        if count < total:
+            fields.append({
+                "path": name,
+                "returned": count,
+                "total": total,
+                "omitted": total - count,
+            })
+    return fields
+
+
+def _summary_truncations(summary: dict) -> list[dict]:
+    id_truncation = summary.get("id_truncation")
+    if not id_truncation:
+        return []
+    fields = []
+    for field in id_truncation["fields"]:
+        fields.append({
+            "path": f"summary.{field['path']}.ids",
+            "limit_per_cluster": field["limit_per_cluster"],
+            "truncated_clusters": field["truncated_clusters"],
+            "omitted": field["omitted_ids"],
+        })
+    return fields
+
+
+def _recommended_limit_commands(
+    file_path: str,
+    *,
+    with_ids: bool,
+    with_summary: bool,
+) -> list[str]:
+    commands = []
+    if with_summary:
+        commands.extend([
+            f"agentcad inspect {file_path} --summary --limit 500",
+            f"agentcad inspect {file_path} --summary --no-limit",
+        ])
+    if with_ids:
+        commands.extend([
+            f"agentcad inspect {file_path} --ids --limit 500",
+            f"agentcad inspect {file_path} --ids --no-limit",
+        ])
+    if not with_summary:
+        commands.insert(0, f"agentcad inspect {file_path} --summary")
+    return commands
 
 
 def _compute_notes(payload: dict) -> list:

--- a/src/agentcad/commands/measure.py
+++ b/src/agentcad/commands/measure.py
@@ -12,6 +12,8 @@ from agentcad.commands._daemon_routing import (
     maybe_spawn_daemon_for_next_run,
 )
 
+DEFAULT_FEATURE_LIMIT = 100
+
 
 @click.command("measure")
 @click.argument("file")
@@ -23,16 +25,75 @@ from agentcad.commands._daemon_routing import (
          "Default output stays compact with overall metrics and feature_summary.",
 )
 @click.option(
+    "--cylinders-only",
+    is_flag=True,
+    help="Return only core metrics plus cylindrical feature buckets. "
+         "Useful for large parts when looking for bores or bosses.",
+)
+@click.option(
+    "--diameter",
+    type=float,
+    help="Filter cylindrical feature buckets to this diameter.",
+)
+@click.option(
+    "--tolerance",
+    "diameter_tolerance",
+    type=click.FloatRange(min=0),
+    default=0.5,
+    show_default=True,
+    help="Diameter tolerance used with --diameter.",
+)
+@click.option(
+    "--axis",
+    type=click.Choice(["+x", "-x", "+y", "-y", "+z", "-z", "other"]),
+    help="Filter cylindrical feature buckets by axis label.",
+)
+@click.option(
+    "--limit",
+    "feature_limit",
+    type=click.IntRange(min=1),
+    default=DEFAULT_FEATURE_LIMIT,
+    show_default=True,
+    help="Maximum records per full feature list, and maximum IDs per summary cluster.",
+)
+@click.option(
+    "--no-limit",
+    is_flag=True,
+    help="Return complete feature and summary ID lists. Can be very large.",
+)
+@click.option(
     "--no-daemon",
     is_flag=True,
     default=False,
     help="Skip daemon routing for this run, even if a daemon is running. Useful for debugging.",
 )
-def measure(file, with_features, no_daemon):
+def measure(
+    file,
+    with_features,
+    cylinders_only,
+    diameter,
+    diameter_tolerance,
+    axis,
+    feature_limit,
+    no_limit,
+    no_daemon,
+):
     """Measure dimensions and feature sizes in a STEP/BREP file."""
     argv = ["measure", file]
     if with_features:
         argv.append("--features")
+    if cylinders_only:
+        argv.append("--cylinders-only")
+    if diameter is not None:
+        argv.extend(["--diameter", str(diameter)])
+    if diameter_tolerance != 0.5:
+        argv.extend(["--tolerance", str(diameter_tolerance)])
+    if axis:
+        argv.extend(["--axis", axis])
+    if feature_limit != DEFAULT_FEATURE_LIMIT:
+        argv.extend(["--limit", str(feature_limit)])
+    if no_limit:
+        argv.append("--no-limit")
     maybe_route_through_daemon(argv, no_daemon=no_daemon)
 
     file_path = Path(file)
@@ -134,6 +195,11 @@ def measure(file, with_features, no_daemon):
             str(file_path.resolve()),
             detection,
             with_features=with_features,
+            cylinders_only=cylinders_only,
+            diameter=diameter,
+            diameter_tolerance=diameter_tolerance,
+            axis=axis,
+            feature_limit=None if no_limit else feature_limit,
         )
         maybe_spawn_daemon_for_next_run(no_daemon=no_daemon)
         return
@@ -177,12 +243,27 @@ def _emit_malformed(file: str, detection: dict) -> None:
     }, exit_code=1)
 
 
-def _measure_tier0(file_path: str, detection: dict, *, with_features: bool) -> None:
+def _measure_tier0(
+    file_path: str,
+    detection: dict,
+    *,
+    with_features: bool,
+    cylinders_only: bool,
+    diameter: float | None,
+    diameter_tolerance: float,
+    axis: str | None,
+    feature_limit: int | None,
+) -> None:
     try:
         payload = measure_tier0_payload(
             file_path,
             detection,
             with_features=with_features,
+            cylinders_only=cylinders_only,
+            diameter=diameter,
+            diameter_tolerance=diameter_tolerance,
+            axis=axis,
+            feature_limit=feature_limit,
         )
     except Exception as exc:
         _emit({
@@ -206,6 +287,11 @@ def measure_tier0_payload(
     detection: dict,
     *,
     with_features: bool = False,
+    cylinders_only: bool = False,
+    diameter: float | None = None,
+    diameter_tolerance: float = 0.5,
+    axis: str | None = None,
+    feature_limit: int | None = DEFAULT_FEATURE_LIMIT,
 ) -> dict:
     from agentcad.metrics import compute_metrics
     from agentcad.step_io import load_cad_shape
@@ -213,8 +299,21 @@ def measure_tier0_payload(
 
     topo_shape = load_cad_shape(file_path)
     metrics = compute_metrics(topo_shape)
-    feature_summary = topo_ids.summary_entries(topo_shape)
-    cylindrical_features = _cylindrical_features(topo_shape)
+    cylindrical_features = _filter_cylindrical_features(
+        _cylindrical_features(topo_shape),
+        diameter=diameter,
+        diameter_tolerance=diameter_tolerance,
+        axis=axis,
+    )
+
+    next_actions = [
+        "read cylindrical_features for diameter, count, axis, and representative centers",
+        f"agentcad measure {file_path} --features --limit 500 — include bounded face/edge measurements",
+    ] if cylinders_only else [
+        "read metrics.dimensions and feature_summary — use the included "
+        "measurement fields before switching to inspect",
+        f"agentcad inspect {file_path} --ids — get feature IDs for targeted edits",
+    ]
 
     payload = {
         "command": "measure",
@@ -226,23 +325,135 @@ def measure_tier0_payload(
         "metrics": metrics,
         "validity": {"is_valid": metrics["is_valid"]},
         "cylindrical_features": cylindrical_features,
-        "feature_summary": feature_summary,
-        "next_actions": [
-            "read metrics.dimensions and feature_summary — use the included "
-            "measurement fields before switching to inspect",
-            f"agentcad inspect {file_path} --ids — get feature IDs for targeted edits",
-        ],
+        "next_actions": next_actions,
         "more_at": "agentcad docs measure",
     }
 
-    if with_features:
-        payload["features"] = {
-            "solids": topo_ids.solid_entries(topo_shape),
-            "faces": topo_ids.face_entries(topo_shape),
-            "edges": topo_ids.edge_entries(topo_shape),
+    if diameter is not None or axis is not None or cylinders_only:
+        payload["query"] = {
+            **({"diameter_mm": diameter} if diameter is not None else {}),
+            **({"diameter_tolerance_mm": diameter_tolerance} if diameter is not None else {}),
+            **({"axis": axis} if axis is not None else {}),
+            **({"cylinders_only": True} if cylinders_only else {}),
+        }
+
+    truncations = []
+    if not cylinders_only:
+        payload["feature_summary"] = topo_ids.summary_entries(
+            topo_shape,
+            id_limit=feature_limit,
+        )
+        truncations.extend(_summary_truncations(payload["feature_summary"]))
+
+    if with_features and not cylinders_only:
+        features, feature_truncations = _feature_lists(topo_shape, feature_limit)
+        payload["features"] = features
+        truncations.extend(feature_truncations)
+
+    if truncations:
+        payload["truncation"] = {
+            "limited": True,
+            "limit": feature_limit,
+            "fields": truncations,
+            "recommended_commands": _recommended_limit_commands(
+                file_path,
+                with_features=with_features,
+            ),
         }
 
     return payload
+
+
+def _feature_lists(topo_shape, limit: int | None) -> tuple[dict, list[dict]]:
+    from agentcad import topo_ids
+
+    counts = topo_ids.topology_counts(topo_shape)
+    features = {
+        "solids": topo_ids.solid_entries(topo_shape, limit=limit),
+        "faces": topo_ids.face_entries(topo_shape, limit=limit),
+        "edges": topo_ids.edge_entries(topo_shape, limit=limit),
+    }
+    return features, _list_truncations(
+        "features",
+        counts,
+        {
+            "solids": len(features["solids"]),
+            "faces": len(features["faces"]),
+            "edges": len(features["edges"]),
+        },
+        limit,
+    )
+
+
+def _list_truncations(
+    prefix: str,
+    totals: dict,
+    returned: dict,
+    limit: int | None,
+) -> list[dict]:
+    if limit is None:
+        return []
+    fields = []
+    for name, total in totals.items():
+        count = returned[name]
+        if count < total:
+            fields.append({
+                "path": f"{prefix}.{name}",
+                "returned": count,
+                "total": total,
+                "omitted": total - count,
+            })
+    return fields
+
+
+def _summary_truncations(summary: dict) -> list[dict]:
+    id_truncation = summary.get("id_truncation")
+    if not id_truncation:
+        return []
+    fields = []
+    for field in id_truncation["fields"]:
+        fields.append({
+            "path": f"feature_summary.{field['path']}.ids",
+            "limit_per_cluster": field["limit_per_cluster"],
+            "truncated_clusters": field["truncated_clusters"],
+            "omitted": field["omitted_ids"],
+        })
+    return fields
+
+
+def _recommended_limit_commands(file_path: str, *, with_features: bool) -> list[str]:
+    commands = [
+        f"agentcad measure {file_path} --cylinders-only",
+    ]
+    if with_features:
+        commands.extend([
+            f"agentcad measure {file_path} --features --limit 500",
+            f"agentcad measure {file_path} --features --no-limit",
+        ])
+    else:
+        commands.extend([
+            f"agentcad measure {file_path} --limit 500",
+            f"agentcad measure {file_path} --no-limit",
+        ])
+    return commands
+
+
+def _filter_cylindrical_features(
+    features: list[dict],
+    *,
+    diameter: float | None,
+    diameter_tolerance: float,
+    axis: str | None,
+) -> list[dict]:
+    filtered = []
+    for feature in features:
+        if diameter is not None:
+            if abs(feature["diameter_mm"] - diameter) > diameter_tolerance:
+                continue
+        if axis is not None and feature.get("axis") != axis:
+            continue
+        filtered.append(feature)
+    return filtered
 
 
 def _cylindrical_features(topo_shape, *, precision: float = 0.1) -> list[dict]:

--- a/src/agentcad/mcp/server.py
+++ b/src/agentcad/mcp/server.py
@@ -141,29 +141,77 @@ def export(step_file: str, formats: str, cwd: str) -> dict:
 
 
 @mcp.tool()
-def measure(file: str, cwd: str, features: bool = False) -> dict:
+def measure(
+    file: str,
+    cwd: str,
+    features: bool = False,
+    cylinders_only: bool = False,
+    diameter: float | None = None,
+    tolerance: float = 0.5,
+    axis: str | None = None,
+    limit: int | None = None,
+    no_limit: bool = False,
+) -> dict:
     """Measure dimensions and feature sizes in a STEP/BREP file.
 
     Args:
         file: Path to the STEP/STP/BREP file.
         cwd: Project directory.
         features: Include full per-solid, per-face, and per-edge measurement lists.
+        cylinders_only: Return only cylindrical feature buckets and core metrics.
+        diameter: Optional cylindrical feature diameter filter.
+        tolerance: Diameter tolerance used with diameter.
+        axis: Optional axis filter (+x, -x, +y, -y, +z, -z, other).
+        limit: Optional maximum records per feature list.
+        no_limit: Return complete feature lists. Can be very large.
     """
     args = ["measure", file]
     if features:
         args.append("--features")
+    if cylinders_only:
+        args.append("--cylinders-only")
+    if diameter is not None:
+        args.extend(["--diameter", str(diameter)])
+    if tolerance != 0.5:
+        args.extend(["--tolerance", str(tolerance)])
+    if axis:
+        args.extend(["--axis", axis])
+    if limit is not None:
+        args.extend(["--limit", str(limit)])
+    if no_limit:
+        args.append("--no-limit")
     return _invoke(args, cwd=cwd)
 
 
 @mcp.tool()
-def inspect(file: str, cwd: str) -> dict:
+def inspect(
+    file: str,
+    cwd: str,
+    ids: bool = False,
+    summary: bool = False,
+    limit: int | None = None,
+    no_limit: bool = False,
+) -> dict:
     """Inspect topology of a STEP file (solids, shells, faces, edges, validity).
 
     Args:
         file: Path to the STEP file.
         cwd: Project directory.
+        ids: Include per-feature ID lists.
+        summary: Include compact face/edge clusters.
+        limit: Optional maximum records per ID list and IDs per summary cluster.
+        no_limit: Return complete ID lists. Can be very large.
     """
-    return _invoke(["inspect", file], cwd=cwd)
+    args = ["inspect", file]
+    if ids:
+        args.append("--ids")
+    if summary:
+        args.append("--summary")
+    if limit is not None:
+        args.extend(["--limit", str(limit)])
+    if no_limit:
+        args.append("--no-limit")
+    return _invoke(args, cwd=cwd)
 
 
 @mcp.tool()

--- a/src/agentcad/topo_ids.py
+++ b/src/agentcad/topo_ids.py
@@ -12,22 +12,25 @@ This module is the single source of truth for that mapping. Both
 the IDs they exchange are identical.
 
 Public API:
-    solid_entries(shape) -> list[dict]   # id, volume, bbox
-    face_entries(shape)  -> list[dict]   # id, normal, area, centroid, bbox
-    edge_entries(shape)  -> list[dict]   # id, length, endpoints
+    solid_entries(shape, limit=None) -> list[dict]   # id, volume, bbox
+    face_entries(shape, limit=None)  -> list[dict]   # id, normal, area, centroid, bbox
+    edge_entries(shape, limit=None)  -> list[dict]   # id, length, endpoints
+    topology_counts(shape) -> dict                   # total solids/faces/edges
     pick_face_topods(shape, face_id) -> TopoDS_Face
     pick_edge_topods(shape, edge_id) -> TopoDS_Edge
 """
 from typing import Any
 
 
-def solid_entries(topo_shape) -> list[dict]:
+def solid_entries(topo_shape, *, limit: int | None = None) -> list[dict]:
     """One dict per solid in `topo_shape`. IDs are 1-indexed."""
     from OCP.TopAbs import TopAbs_SOLID
     from OCP.TopoDS import TopoDS
 
     entries = []
     for i, raw in enumerate(_iter_indexed_map(topo_shape, TopAbs_SOLID), start=1):
+        if _limit_reached(entries, limit):
+            break
         solid = TopoDS.Solid_s(raw)
         entries.append({
             "id": i,
@@ -37,13 +40,15 @@ def solid_entries(topo_shape) -> list[dict]:
     return entries
 
 
-def face_entries(topo_shape) -> list[dict]:
+def face_entries(topo_shape, *, limit: int | None = None) -> list[dict]:
     """One dict per face in `topo_shape`. IDs are 1-indexed."""
     from OCP.TopAbs import TopAbs_FACE
     from OCP.TopoDS import TopoDS
 
     entries = []
     for i, raw in enumerate(_iter_indexed_map(topo_shape, TopAbs_FACE), start=1):
+        if _limit_reached(entries, limit):
+            break
         face = TopoDS.Face_s(raw)
         area, centroid = _face_area_and_centroid(face)
         entries.append({
@@ -80,7 +85,7 @@ def _classify_axis(xyz_dict_or_tuple) -> str:
     return "other"
 
 
-def summary_entries(topo_shape) -> dict:
+def summary_entries(topo_shape, *, id_limit: int | None = None) -> dict:
     """Cluster faces and edges into semantic groups for compact reporting.
 
     Replaces the per-feature ID/area/normal/etc. payload with a much smaller
@@ -88,8 +93,8 @@ def summary_entries(topo_shape) -> dict:
     the M60 Phase 4 friction (#131): a 118-face Pump Manifold's `--ids`
     output is 70 KB, blowing the agent's context budget; the summary
     reduces that to a few hundred bytes while preserving the key signals
-    (counts, sizes, axes). IDs are still emitted per cluster (full lists,
-    not truncated — integers are cheap).
+    (counts, sizes, axes). IDs are emitted per cluster and can be capped for
+    large parts.
 
     Cluster shape:
       face_clusters: [
@@ -247,15 +252,19 @@ def summary_entries(topo_shape) -> dict:
         edge_clusters.append(entry)
     edge_clusters.sort(key=lambda e: -e["count"])
 
+    summary_id_truncation = _truncate_cluster_ids(
+        face_clusters, edge_clusters, id_limit
+    )
     return {
         "face_count": sum(e["count"] for e in face_clusters),
         "edge_count": sum(e["count"] for e in edge_clusters),
         "face_clusters": face_clusters,
         "edge_clusters": edge_clusters,
+        **({"id_truncation": summary_id_truncation} if summary_id_truncation else {}),
     }
 
 
-def edge_entries(topo_shape) -> list[dict]:
+def edge_entries(topo_shape, *, limit: int | None = None) -> list[dict]:
     """One dict per edge in `topo_shape`. IDs are 1-indexed.
     For closed edges (circles, splines), the two endpoints coincide."""
     from OCP.TopAbs import TopAbs_EDGE
@@ -263,6 +272,8 @@ def edge_entries(topo_shape) -> list[dict]:
 
     entries = []
     for i, raw in enumerate(_iter_indexed_map(topo_shape, TopAbs_EDGE), start=1):
+        if _limit_reached(entries, limit):
+            break
         edge = TopoDS.Edge_s(raw)
         length, p_first, p_last = _edge_geometry(edge)
         entries.append({
@@ -271,6 +282,17 @@ def edge_entries(topo_shape) -> list[dict]:
             "endpoints": [_xyz(p_first), _xyz(p_last)],
         })
     return entries
+
+
+def topology_counts(topo_shape) -> dict:
+    """Return total indexed feature counts without materializing entries."""
+    from OCP.TopAbs import TopAbs_EDGE, TopAbs_FACE, TopAbs_SOLID
+
+    return {
+        "solids": _indexed_map(topo_shape, TopAbs_SOLID).Extent(),
+        "faces": _indexed_map(topo_shape, TopAbs_FACE).Extent(),
+        "edges": _indexed_map(topo_shape, TopAbs_EDGE).Extent(),
+    }
 
 
 def pick_face_topods(topo_shape, face_id: int):
@@ -304,6 +326,47 @@ def pick_edge_topods(topo_shape, edge_id: int):
 
 
 # --- internals --------------------------------------------------------------
+
+def _limit_reached(entries: list, limit: int | None) -> bool:
+    return limit is not None and len(entries) >= limit
+
+
+def _truncate_cluster_ids(
+    face_clusters: list[dict], edge_clusters: list[dict], id_limit: int | None
+) -> dict | None:
+    if id_limit is None:
+        return None
+
+    fields = []
+    for path, clusters in (
+        ("face_clusters", face_clusters),
+        ("edge_clusters", edge_clusters),
+    ):
+        truncated_clusters = 0
+        omitted = 0
+        for cluster in clusters:
+            ids = cluster.get("ids", [])
+            total = len(ids)
+            if total <= id_limit:
+                continue
+            cluster["ids"] = ids[:id_limit]
+            cluster["ids_total"] = total
+            cluster["ids_omitted"] = total - id_limit
+            cluster["ids_truncated"] = True
+            truncated_clusters += 1
+            omitted += total - id_limit
+        if truncated_clusters:
+            fields.append({
+                "path": path,
+                "limit_per_cluster": id_limit,
+                "truncated_clusters": truncated_clusters,
+                "omitted_ids": omitted,
+            })
+
+    if not fields:
+        return None
+    return {"limited": True, "fields": fields}
+
 
 def _indexed_map(topo_shape, topabs_kind):
     """Build OCCT's IndexedMapOfShape — same call inspect and pick share."""

--- a/tests/test_inspect_ids.py
+++ b/tests/test_inspect_ids.py
@@ -31,6 +31,17 @@ def _box_step(directory: Path, name: str = "box.step") -> Path:
     return path
 
 
+def _many_boxes_step(directory: Path, name: str = "many_boxes.step", count: int = 20) -> Path:
+    solids = [
+        cq.Workplane("XY").box(1, 1, 1).translate((i * 3, 0, 0)).val()
+        for i in range(count)
+    ]
+    compound = cq.Compound.makeCompound(solids)
+    path = directory / name
+    exporters.export(compound, str(path))
+    return path
+
+
 # --- the --ids flag -------------------------------------------------------
 
 class TestInspectIdsFlag:
@@ -157,6 +168,33 @@ class TestInspectIdsFlag:
         assert "id" in joined
         assert "edit" in joined or "stable" in joined
 
+    def test_ids_default_is_bounded_with_truncation_metadata(
+        self, runner, isolated_dir
+    ):
+        step = _many_boxes_step(isolated_dir)
+        result = runner.invoke(cli, ["inspect", str(step), "--ids"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert parsed["face_count"] == 120
+        assert parsed["edge_count"] == 240
+        assert len(parsed["faces"]) == 100
+        assert len(parsed["edges"]) == 100
+        fields = {f["path"]: f for f in parsed["truncation"]["fields"]}
+        assert fields["faces"]["total"] == 120
+        assert fields["edges"]["total"] == 240
+        assert any("--no-limit" in c for c in parsed["truncation"]["recommended_commands"])
+
+    def test_ids_no_limit_restores_complete_lists(self, runner, isolated_dir):
+        step = _many_boxes_step(isolated_dir)
+        result = runner.invoke(cli, ["inspect", str(step), "--ids", "--no-limit"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert len(parsed["faces"]) == parsed["face_count"]
+        assert len(parsed["edges"]) == parsed["edge_count"]
+        assert "truncation" not in parsed
+
 
 # --- the --summary flag (issue #131) --------------------------------------
 
@@ -247,3 +285,18 @@ class TestInspectSummaryFlag:
         joined = " ".join(parsed["next_actions"])
         assert "import" in joined
         assert "pick_face" in joined or "pick_edge" in joined
+
+    def test_summary_cluster_ids_are_bounded(self, runner, isolated_dir):
+        step = _many_boxes_step(isolated_dir)
+        result = runner.invoke(cli, ["inspect", str(step), "--summary", "--limit", "5"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert parsed["summary"]["face_count"] == 120
+        assert "id_truncation" in parsed["summary"]
+        assert "truncation" in parsed
+        recommended = " ".join(parsed["truncation"]["recommended_commands"])
+        assert "--summary --limit 500" in recommended
+        assert "--summary --no-limit" in recommended
+        for cluster in parsed["summary"]["face_clusters"]:
+            assert len(cluster["ids"]) <= 5

--- a/tests/test_measure.py
+++ b/tests/test_measure.py
@@ -38,6 +38,17 @@ def _plate_with_two_holes_step(directory, name="two_holes.step"):
     return path
 
 
+def _many_boxes_step(directory, name="many_boxes.step", count=20):
+    solids = [
+        cq.Workplane("XY").box(1, 1, 1).translate((i * 3, 0, 0)).val()
+        for i in range(count)
+    ]
+    compound = cq.Compound.makeCompound(solids)
+    path = directory / name
+    exporters.export(compound, str(path))
+    return path
+
+
 class TestMeasureCommand:
     def test_measure_returns_json_metrics_and_feature_summary(self, runner, isolated_dir):
         step = _box_step(isolated_dir)
@@ -119,6 +130,69 @@ class TestMeasureCommand:
         assert len(features["edges"]) == 12
         assert "area" in features["faces"][0]
         assert "length" in features["edges"][0]
+
+    def test_measure_features_default_is_bounded(self, runner, isolated_dir):
+        step = _many_boxes_step(isolated_dir)
+        result = runner.invoke(cli, ["measure", str(step), "--features"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert len(parsed["features"]["faces"]) == 100
+        assert len(parsed["features"]["edges"]) == 100
+        fields = {f["path"]: f for f in parsed["truncation"]["fields"]}
+        assert fields["features.faces"]["total"] == 120
+        assert fields["features.edges"]["total"] == 240
+        assert any("--no-limit" in c for c in parsed["truncation"]["recommended_commands"])
+
+    def test_measure_features_no_limit_restores_complete_lists(
+        self, runner, isolated_dir
+    ):
+        step = _many_boxes_step(isolated_dir)
+        result = runner.invoke(cli, ["measure", str(step), "--features", "--no-limit"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert len(parsed["features"]["faces"]) == parsed["metrics"]["face_count"]
+        assert len(parsed["features"]["edges"]) == parsed["metrics"]["edge_count"]
+        assert "truncation" not in parsed
+
+    def test_measure_summary_truncation_recommends_summary_sized_followup(
+        self, runner, isolated_dir
+    ):
+        step = _box_step(isolated_dir)
+        result = runner.invoke(cli, ["measure", str(step), "--limit", "1"])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        recommended = " ".join(parsed["truncation"]["recommended_commands"])
+        assert "measure" in recommended
+        assert "--limit 500" in recommended
+        assert "--no-limit" in recommended
+        assert "--features --no-limit" not in recommended
+
+    def test_measure_cylinders_only_filters_diameter_and_axis(
+        self, runner, isolated_dir
+    ):
+        step = _plate_with_two_holes_step(isolated_dir)
+        result = runner.invoke(cli, [
+            "measure", str(step),
+            "--cylinders-only", "--diameter", "6", "--axis", "+z",
+        ])
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+
+        assert "feature_summary" not in parsed
+        assert "features" not in parsed
+        assert parsed["query"]["cylinders_only"] is True
+        assert parsed["cylindrical_features"] == [{
+            "diameter_mm": 6.0,
+            "count": 2,
+            "axis": "+z",
+            "representative_centers": [
+                {"x": -10.0, "y": 0.0, "z": 0.0},
+                {"x": 10.0, "y": 0.0, "z": 0.0},
+            ],
+        }]
 
     def test_measure_missing_file_error(self, runner, isolated_dir):
         result = runner.invoke(cli, ["measure", "missing.step"])


### PR DESCRIPTION
## Summary
- cap verbose inspect/measure feature lists by default and include truncation metadata with totals and suggested follow-up commands
- add explicit --limit / --no-limit controls and cylinder-focused measure filters for large parts
- expose the same controls through MCP and document the new defaults

Fixes #31

## Testing
- uv run pytest