### PR TITLE
Support raw TopoDS export for fragile STEP edits

### DIFF
--- a/src/agentcad/runners/build123d.py
+++ b/src/agentcad/runners/build123d.py
@@ -133,9 +133,12 @@ def execute(
                     "show_object(s)`), or fuse them first with "
                     "`Compound(children=list(result))` if you want a single part."
                 )
-        if not isinstance(obj, Shape):
+        if not isinstance(obj, Shape) and not _is_topods_shape(obj):
             raise TypeError(
-                f"show_object() expects a build123d Shape, got {type(obj).__name__}"
+                f"show_object() expects a build123d Shape or raw OCP "
+                f"TopoDS_Shape, got {type(obj).__name__}. For fragile STEP "
+                "edits, use `load_step_shape(path)`, build a raw TopoDS "
+                "feature/compound, and pass that to `show_object()`."
             )
         color = None
         if isinstance(options, dict):
@@ -264,10 +267,12 @@ def execute(
     shapes = [obj for obj, _id, _n, _c in captured]
     if len(shapes) == 1:
         native_shape = shapes[0]
+    elif any(_is_topods_shape(s) for s in shapes):
+        native_shape = _make_topods_compound(shapes)
     else:
         native_shape = Compound(children=list(shapes))
 
-    topo_shape = native_shape.wrapped
+    topo_shape = _topods_shape(native_shape)
 
     parts = [
         {
@@ -275,7 +280,7 @@ def execute(
             "explicit_id": explicit_id,
             "name": name,
             "color": color,
-            "topo_shape": obj.wrapped,
+            "topo_shape": _topods_shape(obj),
         }
         for idx, (obj, explicit_id, name, color) in enumerate(captured)
     ]
@@ -536,15 +541,81 @@ def _faces_with_inner_loops(face_objs, face_ids: list[int]) -> list[int]:
     return flagged
 
 
+def _is_topods_shape(obj) -> bool:
+    """Return True for raw OCP TopoDS_Shape / TopoDS_Compound instances."""
+    try:
+        from OCP.TopoDS import TopoDS_Shape
+    except ImportError:
+        return False
+    return isinstance(obj, TopoDS_Shape)
+
+
+def _topods_shape(obj):
+    """Extract the raw TopoDS shape from either build123d or OCP objects."""
+    from build123d import Shape
+
+    if isinstance(obj, Shape):
+        return obj.wrapped
+    if _is_topods_shape(obj):
+        return obj
+    raise TypeError(
+        f"Expected build123d Shape or TopoDS_Shape, got {type(obj).__name__}"
+    )
+
+
+def _make_topods_compound(shapes):
+    """Build a raw OCCT compound without converting through build123d."""
+    from OCP.BRep import BRep_Builder
+    from OCP.TopoDS import TopoDS_Compound
+
+    compound = TopoDS_Compound()
+    builder = BRep_Builder()
+    builder.MakeCompound(compound)
+    for shape in shapes:
+        builder.Add(compound, _topods_shape(shape))
+    return compound
+
+
+def _export_topods_step(shape, path: str) -> None:
+    """Write a raw TopoDS shape through OCCT's STEP writer."""
+    from OCP.IFSelect import IFSelect_RetDone
+    from OCP.STEPControl import STEPControl_AsIs, STEPControl_Writer
+    from agentcad.native_io import silence_native_stdout
+
+    with silence_native_stdout():
+        writer = STEPControl_Writer()
+        status = writer.Transfer(shape, STEPControl_AsIs)
+        if status != IFSelect_RetDone:
+            raise RuntimeError(f"OCCT STEP transfer failed with status {status}")
+        status = writer.Write(path)
+        if status != IFSelect_RetDone:
+            raise RuntimeError(f"OCCT STEP write failed with status {status}")
+
+
 def export_step(native_shape: Any, path: str) -> None:
-    """Write STEP using build123d's native ``export_step``."""
+    """Write STEP using build123d, or OCCT directly for raw TopoDS shapes."""
+    if _is_topods_shape(native_shape):
+        _export_topods_step(native_shape, path)
+        return
+
     from build123d import export_step as _export
 
     _export(native_shape, path)
 
 
 def export_stl(native_shape: Any, path: str) -> None:
-    """Write STL using build123d's native ``export_stl``."""
+    """Write STL using build123d, or OCCT directly for raw TopoDS shapes."""
+    if _is_topods_shape(native_shape):
+        from OCP.BRepMesh import BRepMesh_IncrementalMesh
+        from OCP.StlAPI import StlAPI_Writer
+
+        BRepMesh_IncrementalMesh(native_shape, 0.1)
+        writer = StlAPI_Writer()
+        ok = writer.Write(native_shape, path)
+        if ok is False:
+            raise RuntimeError(f"OCCT STL write failed for {path}")
+        return
+
     from build123d import export_stl as _export
 
     _export(native_shape, path)

--- a/tests_b3d/test_run_end_to_end.py
+++ b/tests_b3d/test_run_end_to_end.py
@@ -139,6 +139,38 @@ class TestVersionDirectory:
         assert (isolated_dir / "v1_one").is_dir()
         assert (isolated_dir / "v2_two").is_dir()
 
+    def test_raw_topods_compound_step_export_path(self, runner, isolated_dir):
+        """Preserve a source STEP as raw TopoDS and add a raw OCCT feature."""
+        _init(runner, isolated_dir)
+        _write(isolated_dir, "source.py", SIMPLE)
+        first = _run(runner, "source.py", "--output", "source", "--no-preview")
+        assert first.exit_code == 0, first.output
+
+        raw_edit = """\
+from build123d import Box
+from OCP.BRep import BRep_Builder
+from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCP.gp import gp_Pnt
+from OCP.TopoDS import TopoDS_Compound
+
+base = load_step_shape("v1_source/output.step")
+feature = BRepPrimAPI_MakeBox(gp_Pnt(20, 0, 0), 2, 2, 2).Shape()
+compound = TopoDS_Compound()
+builder = BRep_Builder()
+builder.MakeCompound(compound)
+builder.Add(compound, base)
+builder.Add(compound, feature)
+show_object(compound, name="raw_topods_edit")
+"""
+        _write(isolated_dir, "raw_edit.py", raw_edit)
+        second = _run(runner, "raw_edit.py", "--output", "raw", "--no-preview")
+        assert second.exit_code == 0, second.output
+        parsed = json.loads(second.stdout)
+        assert parsed["runtime"] == "build123d"
+        assert parsed["outputs"]["step"] == "v2_raw/output.step"
+        assert (isolated_dir / "v2_raw" / "output.step").exists()
+        assert parsed["metrics"]["volume"] > 1000.0
+
 
 # ---------- preview (default on) ----------
 

--- a/tests_b3d/test_runner.py
+++ b/tests_b3d/test_runner.py
@@ -127,6 +127,46 @@ def test_step_export_accepts_build123d_shape(tmp_path):
     assert out.exists() and out.stat().st_size > 0
 
 
+_RAW_TOPODS_COMPOUND_SCRIPT = """\
+from OCP.BRep import BRep_Builder
+from OCP.BRepPrimAPI import BRepPrimAPI_MakeBox
+from OCP.TopoDS import TopoDS_Compound
+
+compound = TopoDS_Compound()
+builder = BRep_Builder()
+builder.MakeCompound(compound)
+builder.Add(compound, BRepPrimAPI_MakeBox(1, 2, 3).Shape())
+show_object(compound)
+"""
+
+
+def test_show_object_accepts_raw_topods_compound_and_exports_step(tmp_path):
+    """Raw OCCT compounds are the recovery path for fragile STEP edits."""
+    from agentcad.step_io import load_cad_shape
+
+    result = b3d_runner.execute(_RAW_TOPODS_COMPOUND_SCRIPT)
+    assert result.success, result.exception
+    assert type(result.native_shape).__name__ == "TopoDS_Compound"
+    assert type(result.topo_shape).__name__ == "TopoDS_Compound"
+
+    metrics = compute_metrics(result.topo_shape)
+    assert round(metrics["volume"], 2) == 6.0
+
+    out = tmp_path / "raw_compound.step"
+    b3d_runner.export_step(result.native_shape, str(out))
+    assert out.exists() and out.stat().st_size > 0
+    exported = load_cad_shape(out)
+    assert round(compute_metrics(exported)["volume"], 2) == 6.0
+
+
+def test_show_object_rejects_non_shape_with_raw_topods_hint():
+    result = b3d_runner.execute("show_object(object())\n")
+    assert not result.success
+    msg = result.exception or ""
+    assert "TopoDS_Shape" in msg
+    assert "load_step_shape" in msg
+
+
 # --- ShapeList footgun (issue #97) ---
 
 _SINGLE_SHAPELIST_SCRIPT = """\


### PR DESCRIPTION
Before this PR, build123d-mode scripts could load raw TopoDS shapes but `show_object()` and export still forced them through build123d object boundaries, so raw compounds failed before producing `output.step`. After this PR, build123d scripts can show/export raw TopoDS shapes and compounds directly through OCCT, with regression coverage for preserving a source STEP and adding a raw OCCT feature.