### PR TITLE
Fix bbox_point NURBS inflation and module-execution entry points

### DIFF
--- a/src/agentcad/__main__.py
+++ b/src/agentcad/__main__.py
@@ -1,0 +1,13 @@
+"""Enable ``python -m agentcad`` to run the CLI.
+
+Without this, ``python -m agentcad`` fails with "No module named
+agentcad.__main__" and ``python -m agentcad.cli`` exits silently (the
+module imports but never invokes the Click group). Both are common ways
+a fresh agent runs the tool from a checkout — per CLAUDE.md's validation
+guidance — without installing the console script, so route them to the
+same entry point.
+"""
+from agentcad.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -294,3 +294,9 @@ cli.add_command(run)
 cli.add_command(skill)
 cli.add_command(subscribe)
 cli.add_command(view)
+
+
+if __name__ == "__main__":
+    # Allow `python -m agentcad.cli ...`; without this the module imports
+    # and exits silently. See also agentcad/__main__.py for `python -m agentcad`.
+    cli()

--- a/src/agentcad/helpers.py
+++ b/src/agentcad/helpers.py
@@ -8,6 +8,7 @@ from OCP.Bnd import Bnd_Box
 from OCP.BRepAlgoAPI import BRepAlgoAPI_Fuse
 from OCP.BRep import BRep_Builder
 from OCP.BRepBndLib import BRepBndLib
+from OCP.BRepTools import BRepTools
 from OCP.BRepBuilderAPI import (
     BRepBuilderAPI_MakeEdge,
     BRepBuilderAPI_MakeWire,
@@ -302,8 +303,16 @@ def bbox_point(shape, x="center", y="center", z="center"):
                 f"Invalid value '{val}' for {name}. Must be one of: {', '.join(valid)}"
             )
 
+    # AddOptimal_s, not Add_s — Add_s reads B-spline/NURBS bounds off the
+    # control-point poles, which sit outside the trimmed geometry. For a
+    # placement helper that's a real footgun: bbox_point(shape, x="max")
+    # would return a point floating in space beyond the actual body, so
+    # place_at / assemble would mis-seat NURBS parts. AddOptimal_s gives a
+    # tight box on the same basis as `agentcad measure`. Clean_s first to
+    # drop cached triangulation (matches metrics.compute_metrics).
+    BRepTools.Clean_s(shape)
     box = Bnd_Box()
-    BRepBndLib.Add_s(shape, box)
+    BRepBndLib.AddOptimal_s(shape, box)
     xmin, ymin, zmin, xmax, ymax, zmax = box.Get()
 
     def _pick(lo, hi, spec):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -382,6 +382,33 @@ class TestBboxPoint:
         assert isinstance(pt, tuple)
         assert len(pt) == 3
 
+    def test_not_inflated_by_nurbs_poles(self):
+        """A B-spline/NURBS body must report its trimmed extents, not the
+        control-point poles. Under the old Add_s, the max corner of this
+        radius-180 disk floated out past ~198 in X/Y, mis-seating place_at."""
+        from OCP.gp import gp_Ax2, gp_Dir, gp_Pnt, gp_Vec
+        from OCP.Geom import Geom_Circle
+        from OCP.GeomConvert import GeomConvert
+        from OCP.BRepBuilderAPI import (
+            BRepBuilderAPI_MakeEdge,
+            BRepBuilderAPI_MakeFace,
+            BRepBuilderAPI_MakeWire,
+        )
+        from OCP.BRepPrimAPI import BRepPrimAPI_MakePrism
+
+        bspline = GeomConvert.CurveToBSplineCurve_s(
+            Geom_Circle(gp_Ax2(gp_Pnt(0, 0, 0), gp_Dir(0, 0, 1)), 180.0)
+        )
+        edge = BRepBuilderAPI_MakeEdge(bspline).Edge()
+        wire = BRepBuilderAPI_MakeWire(edge).Wire()
+        face = BRepBuilderAPI_MakeFace(wire, True).Face()
+        solid = BRepPrimAPI_MakePrism(face, gp_Vec(0, 0, 134.0)).Shape()
+
+        x_max, y_max, z_max = bbox_point(solid, "max", "max", "max")
+        assert x_max == pytest.approx(180.0, abs=0.5)
+        assert y_max == pytest.approx(180.0, abs=0.5)
+        assert z_max == pytest.approx(134.0, abs=0.5)
+
 
 # ── place_at tests ───────────────────────────────────────────
 

--- a/tests/test_module_execution.py
+++ b/tests/test_module_execution.py
@@ -1,0 +1,59 @@
+"""`python -m agentcad` / `python -m agentcad.cli` must run the CLI.
+
+Both are common ways a fresh agent runs the tool from a checkout without
+installing the console script (see CLAUDE.md's validation guidance). They
+used to be footguns: `python -m agentcad` failed with "No module named
+agentcad.__main__", and `python -m agentcad.cli` imported the module and
+exited silently (exit 0, no output) because there was no
+``if __name__ == "__main__"`` guard. A fresh agent reading that silent
+success could mistake it for a broken or empty result.
+
+These run the real interpreter via subprocess — CliRunner can't catch a
+missing module entry point or a missing __main__ guard.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_SRC = str(Path(__file__).resolve().parents[1] / "src")
+
+
+def _run_module(module: str, *args):
+    """Invoke `python -m <module> <args>` against the current checkout."""
+    env = dict(os.environ)
+    env["PYTHONPATH"] = _SRC + os.pathsep + env.get("PYTHONPATH", "")
+    return subprocess.run(
+        [sys.executable, "-m", module, *args],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+@pytest.mark.parametrize("module", ["agentcad", "agentcad.cli"])
+def test_module_execution_runs_cli(module):
+    # `docs` needs no manifest, no file, and no OCCT import — a clean probe
+    # that the Click group actually ran and emitted its JSON contract.
+    result = _run_module(module, "docs", "commands")
+    assert result.returncode == 0, (
+        f"`python -m {module} docs commands` exited {result.returncode}\n"
+        f"stdout={result.stdout[:300]!r} stderr={result.stderr[:300]!r}"
+    )
+    assert result.stdout.strip(), (
+        f"`python -m {module}` produced no output — the entry point did not "
+        f"invoke the CLI (silent-success footgun)."
+    )
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "docs"
+    assert parsed["status"] == "success"
+
+
+@pytest.mark.parametrize("module", ["agentcad", "agentcad.cli"])
+def test_module_execution_help_exits_zero(module):
+    result = _run_module(module, "--help")
+    assert result.returncode == 0
+    assert "Usage" in result.stdout


### PR DESCRIPTION
Follow-up to #35 / #28 — the two pre-existing footguns called out there but left out of that PR's scope.

## 1. `helpers.bbox_point` inflated on NURBS geometry

`bbox_point` used `BRepBndLib.Add_s`, which reads B-spline/NURBS bounds off the geometry's control-point **poles** — the same root cause fixed for `measure` in #35. As a *placement* helper this is worse than a wrong readout: `bbox_point(shape, x="max")` returned a point floating outside the actual body, so `place_at` / `assemble` would mis-seat NURBS parts.

Switched to `Clean_s` + `AddOptimal_s`, so script-side placement is on the same tight basis as `agentcad measure`. On a radius-180 B-spline disk the max corner now reads `180` (was ~`198` under `Add_s`).

This is a behavioral change to placement output, but in the correct direction — it only moves NURBS parts, and toward their true extents.

## 2. Module-execution entry points were broken

- `python -m agentcad` → `No module named agentcad.__main__`.
- `python -m agentcad.cli` → exited **silently** (exit 0, no output): the module imported but never invoked the Click group.

Both are documented ways a fresh agent runs the tool from a checkout without installing the console script (CLAUDE.md validation guidance), and the silent exit-0 reads as a broken/empty result. Added `agentcad/__main__.py` and an `if __name__ == "__main__"` guard in `cli.py`, both routing to `cli()`.

## Tests

- `bbox_point` NURBS regression (radius-180 disk; max corner ~180 not ~198).
- Subprocess tests that both `python -m agentcad` and `python -m agentcad.cli` emit the CLI's JSON contract and exit 0.
- Full suite: **982 passed, 1 skipped** (only `test_mcp_server.py` excluded locally — `mcp` extra not installed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)