### PR TITLE
Add browser smoke for group review viewer

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -47,3 +47,26 @@ jobs:
 
       - name: Run Windows-relevant guardrails
         run: pytest tests/test_daemon_platform.py tests_b3d/test_parity_guardrail.py -q
+
+  browser-smoke:
+    runs-on: ubuntu-22.04
+    name: Browser viewer smoke
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install agentcad + browser test dependencies
+        run: pip install -e .[mcp,dev]
+
+      - name: Install Playwright Chromium
+        run: python -m playwright install --with-deps chromium
+
+      - name: Run browser viewer smoke
+        env:
+          AGENTCAD_BROWSER_SMOKE: "1"
+        run: pytest tests/test_viewer_browser.py -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
 
 [project.optional-dependencies]
 mcp = ["mcp>=1.0.0"]
-dev = ["pytest>=8.0", "pytest-timeout>=2.0"]
+dev = ["pytest>=8.0", "pytest-timeout>=2.0", "playwright>=1.40"]
 
 [project.urls]
 Repository = "https://github.com/jdilla1277/agentcad"
@@ -62,3 +62,6 @@ testpaths = ["tests", "tests_b3d"]
 # preview renders). Individual tests can override via the
 # @pytest.mark.timeout decorator if they truly need longer.
 timeout = 120
+markers = [
+    "browser: browser-level viewer smoke tests that require Playwright browsers",
+]

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -352,12 +352,18 @@ const hasReview = REVIEW && (REVIEW.measure || REVIEW.check_spec);
 const partObjects = new Map();
 const partRows = new Map();
 const groupRows = new Map();
+let currentMode = null;
+let viewerReady = false;
 let partState = {
   selected: (PART_REVIEW && (PART_REVIEW.selected || PART_REVIEW.focus)) || null,
   focus: (PART_REVIEW && PART_REVIEW.focus) || null,
   hidden: new Set((PART_REVIEW && PART_REVIEW.hidden) || []),
   isolated: new Set((PART_REVIEW && PART_REVIEW.isolated) || []),
   ghostRest: Boolean(PART_REVIEW && PART_REVIEW.ghost_rest),
+};
+window.agentcadViewer = {
+  debugState: viewerDebugState,
+  lastState: null,
 };
 
 // Disable buttons that lack data
@@ -608,6 +614,58 @@ function allPartMeshes() {
   return Array.from(partObjects.values()).flat();
 }
 
+function meshMaterials(mesh) {
+  if (!mesh.material) return [];
+  return Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+}
+
+function meshIsGhosted(mesh) {
+  const materials = meshMaterials(mesh);
+  return materials.length > 0 && materials.every(m => m.transparent && m.opacity <= 0.2);
+}
+
+function viewerDebugState() {
+  return {
+    ready: viewerReady,
+    mode: currentMode,
+    review: PART_REVIEW,
+    parts: PARTS.map(p => {
+      const meshes = partObjects.get(p.id) || [];
+      const visibleMeshes = meshes.filter(m => m.visible);
+      return {
+        id: p.id,
+        part_of: p.part_of || null,
+        mesh_count: meshes.length,
+        visible_mesh_count: visibleMeshes.length,
+        visible: visibleMeshes.length > 0,
+        hidden: partState.hidden.has(p.id),
+        isolated: partState.isolated.has(p.id),
+        selected: partState.selected === p.id || partState.isolated.has(p.id),
+        ghosted: visibleMeshes.length > 0 && visibleMeshes.every(meshIsGhosted),
+      };
+    }),
+    groups: GROUPS.map(g => {
+      const ids = groupPartIds(g.id);
+      return {
+        id: g.id,
+        part_ids: ids,
+        hidden: allMembersInSet(ids, partState.hidden),
+        isolated: allMembersInSet(ids, partState.isolated),
+        selected: ids.includes(partState.selected) || allMembersInSet(ids, partState.isolated),
+      };
+    }),
+    ghost_rest: partState.ghostRest,
+  };
+}
+
+function publishViewerDebugState() {
+  if (!window.agentcadViewer) return;
+  window.agentcadViewer.lastState = viewerDebugState();
+  window.dispatchEvent(new CustomEvent('agentcad:viewer-state', {
+    detail: window.agentcadViewer.lastState,
+  }));
+}
+
 function applyPartState() {
   if (!hasParts) return;
   for (const p of PARTS) {
@@ -656,6 +714,7 @@ function applyPartState() {
     const shouldGhost = partState.ghostRest && !partIsPrimary(partId);
     mesh.material = shouldGhost ? mesh.userData.ghostMaterial : mesh.userData.originalMaterial;
   }
+  publishViewerDebugState();
 }
 
 function selectPart(partId, { focus=false }={}) {
@@ -1143,10 +1202,11 @@ Promise.all([
   fitCamera();
   applyPartState();
   if (partState.focus) focusPart(partState.focus);
+  viewerReady = true;
+  publishViewerDebugState();
 });
 
 // ---- Mode switching ----
-let currentMode = null;
 let currentScene = sceneA_single;
 let splitMode = false;
 resize();

--- a/tests/test_viewer_browser.py
+++ b/tests/test_viewer_browser.py
@@ -1,0 +1,142 @@
+import json
+import os
+
+import pytest
+
+from agentcad.cli import cli
+
+
+GROUPED_PARTS_SCRIPT = """\
+import cadquery as cq
+base = cq.Workplane("XY").box(20, 10, 2)
+rib = cq.Workplane("XY").box(3, 14, 4).translate((0, 0, 3))
+pin = cq.Workplane("XY").circle(1).extrude(5).translate((8, 0, 0))
+show_object(base, id="base_plate", name="Base Plate", options={
+    "part_of": "frame", "group_color": "steelblue"
+})
+show_object(rib, id="center_rib", name="Center Rib", options={
+    "part_of": "frame", "group_color": "steelblue"
+})
+show_object(pin, id="locator_pin", name="Locator Pin", options={"color": "coral"})
+"""
+
+
+pytestmark = pytest.mark.browser
+
+
+def _require_playwright():
+    if os.environ.get("AGENTCAD_BROWSER_SMOKE") != "1":
+        pytest.skip("set AGENTCAD_BROWSER_SMOKE=1 to run browser smoke tests")
+    try:
+        from playwright.sync_api import sync_playwright
+    except ModuleNotFoundError as exc:
+        pytest.fail(f"Playwright is required for browser smoke tests: {exc}")
+    return sync_playwright
+
+
+def _canvas_pixel_summary(page):
+    return page.evaluate(
+        """() => {
+          const canvas = document.getElementById('canvas');
+          const probe = document.createElement('canvas');
+          probe.width = canvas.width;
+          probe.height = canvas.height;
+          const ctx = probe.getContext('2d', { willReadFrequently: true });
+          ctx.drawImage(canvas, 0, 0);
+          const data = ctx.getImageData(0, 0, probe.width, probe.height).data;
+          let nonBackground = 0;
+          for (let i = 0; i < data.length; i += 4) {
+            const r = data[i], g = data[i + 1], b = data[i + 2], a = data[i + 3];
+            if (a > 0 && (Math.abs(r - 239) > 4 || Math.abs(g - 239) > 4 || Math.abs(b - 239) > 4)) {
+              nonBackground += 1;
+            }
+          }
+          return {
+            width: probe.width,
+            height: probe.height,
+            non_background_pixels: nonBackground,
+          };
+        }"""
+    )
+
+
+def test_group_review_viewer_isolates_group_with_ghost_rest(runner, isolated_dir):
+    sync_playwright = _require_playwright()
+
+    init_result = runner.invoke(cli, ["init", "--name", "browser_smoke"])
+    assert init_result.exit_code == 0, init_result.output
+    script = isolated_dir / "script.py"
+    script.write_text(GROUPED_PARTS_SCRIPT)
+    run_result = runner.invoke(
+        cli,
+        ["run", "script.py", "--output", "grouped", "--no-preview", "--no-daemon"],
+    )
+    assert run_result.exit_code == 0, run_result.output
+
+    view_result = runner.invoke(
+        cli,
+        [
+            "parts",
+            "view",
+            "grouped",
+            "--isolate-group",
+            "frame",
+            "--ghost-rest",
+            "--focus-group",
+            "frame",
+            "--no-open",
+        ],
+    )
+    assert view_result.exit_code == 0, view_result.output
+    viewer = json.loads(view_result.stdout)
+    assert viewer["part_review"]["isolated_groups"] == ["frame"]
+    assert viewer["part_review"]["isolated"] == ["base_plate", "center_rib"]
+
+    with sync_playwright() as playwright:
+        browser = playwright.chromium.launch(headless=True)
+        page = browser.new_page(viewport={"width": 1280, "height": 800})
+        try:
+            page.goto(viewer["url"], wait_until="domcontentloaded")
+            page.wait_for_function(
+                """() => (
+                  window.agentcadViewer
+                  && window.agentcadViewer.debugState
+                  && window.agentcadViewer.debugState().ready === true
+                  && window.agentcadViewer.debugState().parts.every(p => p.mesh_count > 0)
+                )""",
+                timeout=45_000,
+            )
+            page.wait_for_timeout(250)
+
+            state = page.evaluate("window.agentcadViewer.debugState()")
+            parts = {part["id"]: part for part in state["parts"]}
+            groups = {group["id"]: group for group in state["groups"]}
+
+            assert state["mode"] == "single-a"
+            assert state["ghost_rest"] is True
+            assert groups["frame"]["selected"] is True
+            assert groups["frame"]["isolated"] is True
+
+            assert parts["base_plate"]["visible"] is True
+            assert parts["base_plate"]["isolated"] is True
+            assert parts["base_plate"]["ghosted"] is False
+            assert parts["center_rib"]["visible"] is True
+            assert parts["center_rib"]["isolated"] is True
+            assert parts["center_rib"]["ghosted"] is False
+            assert parts["locator_pin"]["visible"] is True
+            assert parts["locator_pin"]["isolated"] is False
+            assert parts["locator_pin"]["ghosted"] is True
+
+            assert page.locator('[data-group-id="frame"]').evaluate(
+                "el => el.classList.contains('selected')"
+            )
+            assert page.locator('[data-part-id="locator_pin"]').evaluate(
+                "el => !el.classList.contains('selected')"
+            )
+
+            pixels = _canvas_pixel_summary(page)
+            assert pixels["width"] > 0
+            assert pixels["height"] > 0
+            assert pixels["non_background_pixels"] > 1000
+        finally:
+            browser.close()


### PR DESCRIPTION
## Summary
- add a CI-enforced Playwright smoke for group review viewers
- verify --isolate-group frame --ghost-rest --focus-group frame loads in Chromium, applies isolated/ghosted part state, and renders a nonblank canvas
- expose a small read-only viewer debug snapshot for browser automation

## Tests
- AGENTCAD_BROWSER_SMOKE=1 .venv/bin/pytest tests/test_viewer_browser.py -q
- .venv/bin/pytest tests/test_viewer_browser.py -q
- .venv/bin/pytest tests/test_run.py::test_run_viewer_embeds_part_groups tests/test_run.py::test_run_grouped_parts_emit_groups_and_inherit_group_color -q
- .venv/bin/pytest tests/test_view.py tests/test_parts.py tests/test_viewer_browser.py -q
- .venv/bin/pytest --collect-only -q