### PR TITLE
Show groups in the static Parts tab

### DIFF
--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -95,11 +95,26 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     padding: 60px 24px 24px; display: none;
     box-sizing: border-box;
   }
-  #parts-view .panel { margin: 0 auto; max-width: 600px; background: #fff; border-radius: 8px; padding: 20px 24px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
+  #parts-view .panel { margin: 0 auto; max-width: 720px; background: #fff; border-radius: 8px; padding: 20px 24px; box-shadow: 0 1px 4px rgba(0,0,0,0.08); }
   #parts-view h3 { margin: 0 0 12px; font-size: 14px; color: #555; font-weight: normal; }
+  #parts-view h4 { margin: 16px 0 8px; font-size: 11px; color: #667085; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
   #parts-view ol { margin: 0; padding-left: 24px; font-family: monospace; font-size: 13px; color: #222; }
   #parts-view ol li { margin: 6px 0; }
   #parts-view .swatch { width: 11px; height: 11px; border: 1px solid rgba(0,0,0,0.18); border-radius: 2px; display: inline-block; margin-right: 8px; vertical-align: -1px; box-sizing: border-box; }
+  #parts-view .group-list { display: grid; gap: 6px; margin-bottom: 10px; }
+  #parts-view .group-row {
+    display: grid; grid-template-columns: 16px minmax(0, 1fr) auto;
+    align-items: center; gap: 8px; padding: 8px 10px;
+    border: 1px solid rgba(0,0,0,0.08); border-radius: 6px;
+    background: #f8fafc; font-family: monospace; font-size: 13px;
+  }
+  #parts-view .group-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: #222; }
+  #parts-view .meta { color: #667085; font-size: 11px; white-space: nowrap; }
+  #parts-view .part-group-tag {
+    display: inline-block; margin-left: 8px; padding: 1px 5px;
+    border: 1px solid rgba(0,0,0,0.12); border-radius: 999px;
+    color: #3f4856; background: #f8fafc; font-size: 11px;
+  }
   #part-controls {
     position: absolute; top: 60px; left: 12px; z-index: 20;
     width: 340px; max-height: calc(100vh - 126px); overflow: auto;
@@ -261,6 +276,11 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
 <div id="parts-view">
   <div class="panel">
     <h3 id="parts-heading">Parts</h3>
+    <div id="parts-groups-section" style="display:none;">
+      <h4>Groups</h4>
+      <div class="group-list" id="parts-groups"></div>
+    </div>
+    <h4 id="parts-list-heading" style="display:none;">Parts</h4>
     <ol id="parts-list"></ol>
   </div>
 </div>
@@ -391,20 +411,7 @@ function setupModeButtons() {
   if (DIFF_OVERLAY_PNG_URL) { document.getElementById('panel-diff-overlay').style.display = ''; document.getElementById('img-diff-overlay').src = DIFF_OVERLAY_PNG_URL; }
 
   if (hasParts) {
-    document.getElementById('parts-heading').textContent = `Parts (${PARTS.length})`;
-    const list = document.getElementById('parts-list');
-    for (const p of PARTS) {
-      const li = document.createElement('li');
-      if (p.color) {
-        const swatch = document.createElement('span');
-        swatch.className = 'swatch';
-        swatch.style.background = p.color;
-        swatch.title = p.color;
-        li.appendChild(swatch);
-      }
-      li.appendChild(document.createTextNode(p.name || p.id));
-      list.appendChild(li);
-    }
+    setupStaticPartsPanel();
     setupPartControls();
   }
   if (hasReview) {
@@ -432,6 +439,69 @@ function groupLabel(group) {
 function groupPartIds(groupId) {
   const group = GROUPS.find(g => g.id === groupId);
   return group ? (group.part_ids || []) : [];
+}
+
+function setupStaticPartsPanel() {
+  document.getElementById('parts-heading').textContent = hasGroups
+    ? `Parts ${PARTS.length} · Groups ${GROUPS.length}`
+    : `Parts (${PARTS.length})`;
+  document.getElementById('parts-list-heading').style.display = hasGroups ? 'block' : 'none';
+
+  const groupsSection = document.getElementById('parts-groups-section');
+  const groupsList = document.getElementById('parts-groups');
+  groupsList.innerHTML = '';
+  groupsSection.style.display = hasGroups ? 'block' : 'none';
+  if (hasGroups) {
+    for (const g of GROUPS) groupsList.appendChild(makeStaticGroupRow(g));
+  }
+
+  const list = document.getElementById('parts-list');
+  list.innerHTML = '';
+  for (const p of PARTS) list.appendChild(makeStaticPartRow(p));
+}
+
+function makeStaticGroupRow(group) {
+  const row = document.createElement('div');
+  row.className = 'group-row';
+  row.dataset.groupId = group.id;
+
+  const swatch = document.createElement('span');
+  swatch.className = 'swatch';
+  swatch.style.background = group.color || '#c0c0c0';
+  swatch.title = group.color || 'group';
+  row.appendChild(swatch);
+
+  const name = document.createElement('span');
+  name.className = 'group-name';
+  name.textContent = groupLabel(group);
+  row.appendChild(name);
+
+  const count = document.createElement('span');
+  count.className = 'meta';
+  const partCount = (group.part_ids || []).length;
+  count.textContent = `${group.id} · ${partCount} ${partCount === 1 ? 'part' : 'parts'}`;
+  row.appendChild(count);
+  return row;
+}
+
+function makeStaticPartRow(part) {
+  const li = document.createElement('li');
+  li.dataset.partId = part.id;
+  if (part.color) {
+    const swatch = document.createElement('span');
+    swatch.className = 'swatch';
+    swatch.style.background = part.color;
+    swatch.title = part.color;
+    li.appendChild(swatch);
+  }
+  li.appendChild(document.createTextNode(partLabel(part)));
+  if (part.part_of) {
+    const tag = document.createElement('span');
+    tag.className = 'part-group-tag';
+    tag.textContent = part.part_of;
+    li.appendChild(tag);
+  }
+  return li;
 }
 
 function setupPartControls() {

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1616,7 +1616,7 @@ def test_run_viewer_parts_panel_includes_named_parts(runner, isolated_dir):
     assert [p.get("name") for p in parts] == ["deck", "pin", "arm"]
     assert [p.get("color") for p in parts] == ["gray", "blue", "red"]
     assert "className = 'swatch'" in viewer_html
-    assert "swatch.style.background = p.color" in viewer_html
+    assert "swatch.style.background = part.color" in viewer_html
     assert "registerPartMeshes(m)" in viewer_html
     assert "attach(sceneA_single, MODEL_A_URL, { onMesh:" in viewer_html
     assert "partMatchesNameExact" in viewer_html
@@ -1658,6 +1658,10 @@ def test_run_viewer_embeds_part_groups(runner, isolated_dir):
         "color": "steelblue",
         "part_ids": ["base_plate", "center_rib"],
     }]
+    assert 'id="parts-groups-section"' in viewer_html
+    assert "makeStaticGroupRow" in viewer_html
+    assert "part-group-tag" in viewer_html
+    assert "Parts ${PARTS.length} · Groups ${GROUPS.length}" in viewer_html
     assert "toggleGroupHidden" in viewer_html
     assert "toggleGroupIsolated" in viewer_html
 

--- a/tests/test_viewer_browser.py
+++ b/tests/test_viewer_browser.py
@@ -127,10 +127,10 @@ def test_group_review_viewer_isolates_group_with_ghost_rest(runner, isolated_dir
             assert parts["locator_pin"]["isolated"] is False
             assert parts["locator_pin"]["ghosted"] is True
 
-            assert page.locator('[data-group-id="frame"]').evaluate(
+            assert page.locator('#part-controls [data-group-id="frame"]').evaluate(
                 "el => el.classList.contains('selected')"
             )
-            assert page.locator('[data-part-id="locator_pin"]').evaluate(
+            assert page.locator('#part-controls [data-part-id="locator_pin"]').evaluate(
                 "el => !el.classList.contains('selected')"
             )
 
@@ -138,5 +138,19 @@ def test_group_review_viewer_isolates_group_with_ghost_rest(runner, isolated_dir
             assert pixels["width"] > 0
             assert pixels["height"] > 0
             assert pixels["non_background_pixels"] > 1000
+
+            page.click("#btn-parts")
+            expect = page.locator("#parts-view")
+            assert expect.evaluate("el => getComputedStyle(el).display === 'block'")
+            assert page.locator("#parts-heading").inner_text() == "Parts 3 · Groups 1"
+            assert page.locator('#parts-groups [data-group-id="frame"]').inner_text() == (
+                "frame\nframe · 2 parts"
+            )
+            assert page.locator('#parts-groups [data-group-id="frame"] .swatch').evaluate(
+                "el => el.style.background === 'steelblue'"
+            )
+            assert page.locator('#parts-list [data-part-id="base_plate"] .part-group-tag').inner_text() == "frame"
+            assert page.locator('#parts-list [data-part-id="center_rib"] .part-group-tag').inner_text() == "frame"
+            assert page.locator('#parts-list [data-part-id="locator_pin"] .part-group-tag').count() == 0
         finally:
             browser.close()

--- a/tests_b3d/test_run_end_to_end.py
+++ b/tests_b3d/test_run_end_to_end.py
@@ -926,6 +926,9 @@ class TestNamedParts:
             "color": "steelblue",
             "part_ids": ["base_plate", "center_rib"],
         }]
+        assert 'id="parts-groups-section"' in viewer_html
+        assert "makeStaticGroupRow" in viewer_html
+        assert "part-group-tag" in viewer_html
         assert "toggleGroupHidden" in viewer_html
         assert "toggleGroupIsolated" in viewer_html
 


### PR DESCRIPTION
## Summary
- add a Groups section to the static Parts tab in viewer.html
- show group color, group name/id, and member count
- show group membership tags next to grouped parts
- extend the browser smoke to click the Parts tab and verify grouped display

## Tests
- AGENTCAD_BROWSER_SMOKE=1 .venv/bin/pytest tests/test_viewer_browser.py -q
- .venv/bin/pytest tests/test_viewer_browser.py -q
- .venv/bin/pytest tests/test_run.py::test_run_viewer_parts_panel_includes_named_parts tests/test_run.py::test_run_viewer_embeds_part_groups tests_b3d/test_run_end_to_end.py::TestNamedParts::test_viewer_embeds_part_groups -q
- .venv/bin/pytest tests/test_view.py tests/test_parts.py tests/test_viewer_browser.py -q
- .venv/bin/pytest --collect-only -q

Visual smoke: .context/parts-tab-groups.png