### PR TITLE
Pause viewer rotation on grab

### DIFF
--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -1385,10 +1385,17 @@ document.getElementById('visible-b').addEventListener('change', e => { if (overl
 
 // Pause/play
 const pauseBtn = document.getElementById('pause-btn');
-pauseBtn.addEventListener('click', () => {
-  controls.autoRotate = !controls.autoRotate;
+function setAutoRotate(enabled) {
+  controls.autoRotate = enabled;
   pauseBtn.innerHTML = controls.autoRotate ? '&#9646;&#9646;' : '&#9654;';
+}
+function pauseAutoRotate() {
+  setAutoRotate(false);
+}
+pauseBtn.addEventListener('click', () => {
+  setAutoRotate(!controls.autoRotate);
 });
+controls.addEventListener('start', pauseAutoRotate);
 
 // Render one frame to the canvas. Shared between the rAF loop and the GIF
 // export, so split-viewport rendering stays consistent.
@@ -1451,7 +1458,7 @@ async function exportGif() {
   const workerUrl = await getGifWorkerUrl();
 
   const wasRotating = controls.autoRotate;
-  controls.autoRotate = false;
+  setAutoRotate(false);
 
   const startPosition = camera.position.clone();
   const startTarget = controls.target.clone();
@@ -1520,7 +1527,7 @@ async function exportGif() {
     camera.position.copy(startPosition);
     controls.target.copy(startTarget);
     camera.lookAt(startTarget);
-    controls.autoRotate = wasRotating;
+    setAutoRotate(wasRotating);
     exportBtn.disabled = false;
     progressDiv.style.display = 'none';
   });

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1711,6 +1711,22 @@ def test_render_unified_includes_export_gif_button(isolated_dir):
     assert "agentcad.dev" in html  # watermark text
 
 
+def test_render_unified_pauses_rotation_on_viewer_interaction(isolated_dir):
+    """Auto-rotation pauses when OrbitControls reports user interaction."""
+    from agentcad.commands.view import _render_unified
+
+    glb = isolated_dir / "fake.glb"
+    glb.write_bytes(b"")
+    out = isolated_dir / "v.html"
+    _render_unified(out, glb_a=glb, label_a="x")
+
+    html = out.read_text()
+    assert "function setAutoRotate(enabled)" in html
+    assert "function pauseAutoRotate()" in html
+    assert "controls.addEventListener('start', pauseAutoRotate);" in html
+    assert "setAutoRotate(wasRotating);" in html
+
+
 def test_render_unified_keeps_preserve_drawing_buffer(isolated_dir):
     """The WebGL renderer must be constructed with `preserveDrawingBuffer: true`.
 

--- a/tests_b3d/test_parity_guardrail.py
+++ b/tests_b3d/test_parity_guardrail.py
@@ -55,6 +55,8 @@ PARITY_MAP: dict[str, str] = {
         "cq_only:unit test on view helper, runtime-agnostic",
     "test_render_unified_includes_export_gif_button":
         "cq_only:unit test on view helper, runtime-agnostic",
+    "test_render_unified_pauses_rotation_on_viewer_interaction":
+        "cq_only:unit test on view helper, runtime-agnostic",
     "test_render_unified_keeps_preserve_drawing_buffer":
         "cq_only:unit test on view helper, runtime-agnostic",
     "test_run_brep_api_error_enriched":


### PR DESCRIPTION
## Summary
- Pause viewer auto-rotation when OrbitControls reports user interaction
- Centralize auto-rotation state updates so the pause/play button stays synced
- Keep GIF export rotation disable/restore using the same state helper
- Add a template regression test for interaction pause behavior

## Verification
- python3 -m py_compile src/agentcad/commands/view.py tests/test_run.py
- pytest tests/test_run.py -k "render_unified" *(blocked locally: missing click dependency)*