### PR TITLE
Preserve Agent view images in part review viewers

### DIFF
--- a/src/agentcad/commands/parts.py
+++ b/src/agentcad/commands/parts.py
@@ -132,6 +132,10 @@ def _slugify_review_name(values):
     return slug[:80] or "all"
 
 
+def _existing_file(path):
+    return path if path.exists() else None
+
+
 def _validate_part_ids(parts, ids):
     available = {str(p.get("id")) for p in parts}
     missing = [part_id for part_id in ids if part_id not in available]
@@ -426,6 +430,9 @@ def view_parts(
         glb_a=glb_path,
         label_a=viewer_label,
         default_mode="single-a",
+        preview_png=_existing_file(version_dir / "preview.png"),
+        diff_side_png=_existing_file(version_dir / "diff_side.png"),
+        diff_overlay_png=_existing_file(version_dir / "diff_overlay.png"),
         parts=parts,
         groups=groups,
         part_review=review_state,

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -99,6 +99,8 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     background: #f8fafc; color: #222; font-size: 12px;
   }
   #agent-view .agent-swatch { width: 10px; height: 10px; border: 1px solid rgba(0,0,0,0.18); border-radius: 2px; display: inline-block; box-sizing: border-box; }
+  #agent-view .empty-state { color: #667085; font-size: 13px; line-height: 1.5; }
+  #agent-view .empty-state strong { display: block; margin-bottom: 4px; color: #222; font-weight: 600; }
   #parts-view {
     position: fixed; top: 0; left: 0; right: 0; bottom: 0;
     background: #f5f5f5; overflow: auto;
@@ -286,6 +288,12 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     <p class="agent-note" id="agent-handoff-note"></p>
     <div class="agent-state-grid" id="agent-handoff-details"></div>
   </div>
+  <div class="panel" id="panel-agent-images-empty" style="display:none;">
+    <div class="empty-state">
+      <strong>No preview images</strong>
+      The agent did not ask for a preview on this run.
+    </div>
+  </div>
   <div class="panel" id="panel-preview" style="display:none;">
     <h3>preview.png — 4-view composite (top + three iso angles) the agent reads by default</h3>
     <img id="img-preview">
@@ -439,6 +447,9 @@ function setupModeButtons() {
 
   // Agent-view panels: show only those with data
   setupAgentHandoffPanel();
+  if (!hasAgentImgs && hasAgentView) {
+    document.getElementById('panel-agent-images-empty').style.display = '';
+  }
   if (PREVIEW_PNG_URL) { document.getElementById('panel-preview').style.display = ''; document.getElementById('img-preview').src = PREVIEW_PNG_URL; }
   if (DIFF_SIDE_PNG_URL) { document.getElementById('panel-diff-side').style.display = ''; document.getElementById('img-diff-side').src = DIFF_SIDE_PNG_URL; }
   if (DIFF_OVERLAY_PNG_URL) { document.getElementById('panel-diff-overlay').style.display = ''; document.getElementById('img-diff-overlay').src = DIFF_OVERLAY_PNG_URL; }

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -208,7 +208,7 @@ def test_parts_show_missing_part_errors_with_available_ids(runner, isolated_dir)
 
 
 def test_parts_view_writes_reproducible_review_viewer(runner, isolated_dir):
-    _write_project(isolated_dir, parts=[
+    version_dir = _write_project(isolated_dir, parts=[
         {
             "id": "base_plate",
             "id_source": "explicit",
@@ -222,6 +222,9 @@ def test_parts_view_writes_reproducible_review_viewer(runner, isolated_dir):
             "color": "steelblue",
         },
     ])
+    (version_dir / "preview.png").write_bytes(b"preview")
+    (version_dir / "diff_side.png").write_bytes(b"diff-side")
+    (version_dir / "diff_overlay.png").write_bytes(b"diff-overlay")
 
     result = runner.invoke(cli, [
         "parts", "view", "assembly",
@@ -270,6 +273,9 @@ def test_parts_view_writes_reproducible_review_viewer(runner, isolated_dir):
     assert "const PART_REVIEW = " in html
     assert '"mode": "part-review"' in html
     assert '"isolated": ["axle_shaft"]' in html
+    assert 'const PREVIEW_PNG_URL = "data:image/png;base64,cHJldmlldw=="' in html
+    assert 'const DIFF_SIDE_PNG_URL = "data:image/png;base64,ZGlmZi1zaWRl"' in html
+    assert 'const DIFF_OVERLAY_PNG_URL = "data:image/png;base64,ZGlmZi1vdmVybGF5"' in html
     assert "Part controls" in html
     assert "Ghost rest" in html
 

--- a/tests/test_viewer_browser.py
+++ b/tests/test_viewer_browser.py
@@ -195,5 +195,11 @@ def test_group_review_viewer_isolates_group_with_ghost_rest(runner, isolated_dir
             assert "Cover Panel (cover_panel)" in page.locator("#agent-handoff-details").inner_text()
             assert "Ghost rest\nOn" in page.locator("#agent-handoff-details").inner_text()
             assert "Lifecycle\nTemporary, not saved" in page.locator("#agent-handoff-details").inner_text()
+            assert page.locator("#panel-agent-images-empty").evaluate(
+                "el => getComputedStyle(el).display === 'block'"
+            )
+            assert "The agent did not ask for a preview on this run." in page.locator(
+                "#panel-agent-images-empty"
+            ).inner_text()
         finally:
             browser.close()


### PR DESCRIPTION
## Summary

- Carries existing `preview.png`, `diff_side.png`, and `diff_overlay.png` into temporary `agentcad parts view` review viewers.
- Keeps the structured `PART_REVIEW` handoff panel from #55, so Agent view now shows images when they exist plus the handoff state.
- Adds a regression test proving part review HTML embeds the image data URIs and `PART_REVIEW` together.

## Why

The M64 closeout screenshot made Agent view look like it had lost the image artifacts. Normal run viewers still had images, but derived parts review viewers were not passing those existing image files into `_render_unified`.

## Validation

- `.venv/bin/python -m pytest tests/test_parts.py tests/test_help.py`
- `AGENTCAD_BROWSER_SMOKE=1 .venv/bin/python -m pytest tests/test_viewer_browser.py`
- Regenerated the M64 closeout demo with preview enabled and verified Agent view shows both panels:
  - `.context/m64-closeout-friction/closeout-agent-view-with-preview.png`
