### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.3.1"
+version = "0.4.0"
 description = "CLI CAD tool for AI agents. Write CadQuery scripts, get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
## Summary

Bump `agentcad` to `0.4.0` for the parts release.

## Release framing

`v0.4.0` makes multi-part CAD reviewable as named, colored, grouped parts that agents and humans can inspect together.

Included since `v0.3.1`:

- Agent view handoff state for part review viewers (#55).
- Existing Agent view preview/diff images carried into `agentcad parts view` review viewers (#56).
- Explicit no-preview empty state in Agent view (#56).

This release is the package baseline for the parts marketing/manual-test story.

## Validation

- `.venv/bin/python -m pytest tests/test_parts.py tests/test_help.py`
- `.venv/bin/python -m build --sdist --wheel --outdir .context/release-dist-0.4.0`
