### PR TITLE
Add render resolution and antialiasing controls

### DIFF
--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -117,7 +117,7 @@ COMMANDS
     --dry-run        Metrics only — no version consumed, no disk artifacts.
 
 \b
-  agentcad render STEP --view SPEC [--zoom N] [--focus x,y,z] [--no-fit] [--name LABEL]
+  agentcad render STEP --view SPEC [--zoom N] [--size WxH] [--msaa N] [--focus x,y,z] [--no-fit] [--name LABEL]
     Render PNG views of an existing STEP file. Same view spec as --render.
 
 \b

--- a/src/agentcad/commands/docs.py
+++ b/src/agentcad/commands/docs.py
@@ -78,12 +78,15 @@ SECTIONS = {
     ),
     "render": (
         "Rendering:\n"
-        "  agentcad render <step_file> --view <spec> [--zoom N] [--name label] "
-        "[--focus x,y,z] [--no-fit]\n"
+        "  agentcad render <step_file> --view <spec> [--zoom N] [--size WxH] "
+        "[--msaa N] [--name label] [--focus x,y,z] [--no-fit]\n"
         "\n"
         "  --view   Named views (front, back, left, right, top, bottom, iso),\n"
         "           comma-separated, 'all', or custom 'azimuth,elevation'.\n"
         "  --zoom   Zoom factor applied after FitAll (default 1.0).\n"
+        "  --size   Output resolution as WIDTHxHEIGHT (default 800x600).\n"
+        "  --msaa   Antialiasing samples, 0-16 (default 0). Nonzero values also\n"
+        "           use 2x supersampling to ensure offscreen antialiasing.\n"
         "  --focus  Camera target point as 'x,y,z'.\n"
         "  --no-fit Skip FitAll (requires --focus).\n"
         "  --name   Custom filename for single-view renders.\n"

--- a/src/agentcad/commands/render.py
+++ b/src/agentcad/commands/render.py
@@ -10,6 +10,10 @@ from agentcad.commands._daemon_routing import (
     maybe_spawn_daemon_for_next_run,
 )
 
+MAX_RENDER_DIMENSION = 8192
+MAX_RENDER_PIXELS = 32_000_000
+MAX_ANTIALIASED_PIXELS = 9_000_000
+
 
 def _is_version_dir(directory):
     """Check if directory matches v\\d+_\\w+ pattern and contains meta.json."""
@@ -34,20 +38,56 @@ def _parse_focus(focus_str):
         raise ValueError(f"Invalid --focus '{focus_str}'. Expected 'x,y,z' (3 numeric values).")
 
 
+def _parse_size(_ctx, _param, value):
+    """Parse a WIDTHxHEIGHT string into a pair of positive pixel dimensions."""
+    match = re.fullmatch(r"(\d+)[xX](\d+)", value)
+    if not match:
+        raise click.BadParameter("expected WIDTHxHEIGHT, for example 2400x1800")
+    components = match.groups()
+    if any(len(component) > 5 for component in components):
+        raise click.BadParameter(
+            f"width and height must not exceed {MAX_RENDER_DIMENSION} pixels"
+        )
+    width, height = (int(component) for component in components)
+    if width < 1 or height < 1:
+        raise click.BadParameter("width and height must be positive")
+    if width > MAX_RENDER_DIMENSION or height > MAX_RENDER_DIMENSION:
+        raise click.BadParameter(
+            f"width and height must not exceed {MAX_RENDER_DIMENSION} pixels"
+        )
+    if width * height > MAX_RENDER_PIXELS:
+        raise click.BadParameter("output size must not exceed 32 million pixels")
+    return width, height
+
+
 @click.command()
 @click.argument("step_file")
 @click.option("--view", required=True, help="View spec: named view(s), 'all', or 'azimuth,elevation'.")
 @click.option("--zoom", default=1.0, type=float, help="Zoom factor (applied after FitAll).")
+@click.option("--size", default="800x600", callback=_parse_size, metavar="WIDTHxHEIGHT",
+              help="Output resolution (default: 800x600).")
+@click.option("--msaa", default=0, type=click.IntRange(min=0, max=16),
+              help="Antialiasing samples; 0 disables antialiasing (default: 0).")
 @click.option("--name", default=None, help="Custom filename for the rendered PNG (single view only).")
 @click.option("--focus", default=None, help="Camera target point 'x,y,z'.")
 @click.option("--no-fit", is_flag=True, default=False, help="Skip FitAll (requires --focus).")
 @click.option("--no-daemon", is_flag=True, default=False, help="Skip daemon routing for this run, even if a daemon is running. Useful for debugging.")
-def render(step_file, view, zoom, name, focus, no_fit, no_daemon):
+def render(step_file, view, zoom, size, msaa, name, focus, no_fit, no_daemon):
     """Render PNG views of an existing STEP file."""
+    if msaa and size[0] * size[1] > MAX_ANTIALIASED_PIXELS:
+        raise click.BadParameter(
+            "antialiased output size must not exceed 9 million pixels",
+            param_hint="--size",
+        )
+
     # Try routing through daemon. Exits before returning if reachable.
     argv = ["render", step_file, "--view", view]
     if zoom != 1.0:
         argv.extend(["--zoom", str(zoom)])
+    if size != (800, 600):
+        argv.extend(["--size", f"{size[0]}x{size[1]}"])
+    if msaa != 0:
+        argv.extend(["--msaa", str(msaa)])
     if name:
         argv.extend(["--name", name])
     if focus:
@@ -92,6 +132,7 @@ def render(step_file, view, zoom, name, focus, no_fit, no_daemon):
             sys.exit(1)
 
     fit = not no_fit
+    width, height = size
 
     # Parse view spec
     try:
@@ -148,8 +189,8 @@ def render(step_file, view, zoom, name, focus, no_fit, no_daemon):
                 filename = f"{spec_value}.png"
                 key = spec_value
             out_path = output_dir / filename
-            render_shape(shape, spec_value, out_path, zoom=zoom,
-                         focus=focus_point, fit=fit)
+            render_shape(shape, spec_value, out_path, width=width, height=height,
+                         zoom=zoom, focus=focus_point, fit=fit, msaa=msaa)
             renders[key] = str(out_path)
         elif spec_type == "custom":
             azimuth, elevation = spec_value
@@ -160,8 +201,9 @@ def render(step_file, view, zoom, name, focus, no_fit, no_daemon):
                 key = _format_custom_angle_name(azimuth, elevation)
                 filename = f"{key}.png"
             out_path = output_dir / filename
-            render_shape_custom(shape, azimuth, elevation, out_path, zoom=zoom,
-                                focus=focus_point, fit=fit)
+            render_shape_custom(shape, azimuth, elevation, out_path,
+                                width=width, height=height, zoom=zoom,
+                                focus=focus_point, fit=fit, msaa=msaa)
             renders[key] = str(out_path)
 
     # Update meta.json if in a version directory

--- a/src/agentcad/render.py
+++ b/src/agentcad/render.py
@@ -94,7 +94,7 @@ def parse_view_spec(spec):
     )
 
 
-def _setup_render(shape, width=800, height=600, parts=None):
+def _setup_render(shape, width=800, height=600, parts=None, msaa=0):
     """Set up offscreen rendering pipeline, returning (view, context)."""
     display_connection = Aspect_DisplayConnection()
     driver = OpenGl_GraphicDriver(display_connection)
@@ -119,6 +119,7 @@ def _setup_render(shape, width=800, height=600, parts=None):
     viewer.SetLightOn(fill_light)
 
     view = viewer.CreateView()
+    view.ChangeRenderingParams().NbMsaaSamples = msaa
     window = Aspect_NeutralWindow()
     window.SetSize(width, height)
     view.SetWindow(window)
@@ -148,13 +149,23 @@ def _setup_render(shape, width=800, height=600, parts=None):
     return view, context
 
 
-def _capture(view, output_path, width=800, height=600):
+def _capture(view, output_path, width=800, height=600, msaa=0):
     """Capture the current view to a PNG file."""
     output_path = Path(output_path)
     output_path.parent.mkdir(parents=True, exist_ok=True)
+    # Some offscreen/software-GL drivers accept NbMsaaSamples but do not apply
+    # it to V3d_View.ToPixMap(). Always render nonzero-MSAA requests at 2x
+    # resolution and downsample so antialiasing is effective on those drivers.
+    capture_scale = 2 if msaa else 1
     pixmap = Image_AlienPixMap()
-    view.ToPixMap(pixmap, width, height)
+    view.ToPixMap(pixmap, width * capture_scale, height * capture_scale)
     pixmap.Save(TCollection_AsciiString(str(output_path)))
+    if capture_scale > 1:
+        from PIL import Image
+
+        with Image.open(output_path) as image:
+            resized = image.resize((width, height), Image.Resampling.LANCZOS)
+            resized.save(output_path)
 
 
 def _apply_camera(view, zoom, focus, fit):
@@ -169,18 +180,19 @@ def _apply_camera(view, zoom, focus, fit):
 
 
 def render_shape(shape, view_name, output_path, width=800, height=600,
-                 zoom=1.0, focus=None, fit=True, parts=None):
+                 zoom=1.0, focus=None, fit=True, parts=None, msaa=0):
     """Render a TopoDS_Shape to a PNG file from the given view."""
     orientation = VIEWS[view_name]
-    view, _ctx = _setup_render(shape, width, height, parts=parts)
+    view, _ctx = _setup_render(shape, width, height, parts=parts, msaa=msaa)
 
     view.SetProj(orientation)
     _apply_camera(view, zoom, focus, fit)
 
-    _capture(view, output_path, width, height)
+    _capture(view, output_path, width, height, msaa=msaa)
 
 
-def render_shape_batch(shape, view_specs, output_paths, width=512, height=512, parts=None):
+def render_shape_batch(shape, view_specs, output_paths, width=512, height=512,
+                       parts=None, msaa=0):
     """Render multiple views of the same shape through ONE viewer setup.
 
     Shares the OpenGL context, lights, and AIS geometry upload across all views —
@@ -193,8 +205,9 @@ def render_shape_batch(shape, view_specs, output_paths, width=512, height=512, p
             custom (azimuth, elevation) tuples in degrees.
         output_paths: Parallel iterable of output PNG paths.
         width, height: Per-view dimensions in pixels.
+        msaa: Number of multisample antialiasing samples; 0 disables MSAA.
     """
-    view, _ctx = _setup_render(shape, width, height, parts=parts)
+    view, _ctx = _setup_render(shape, width, height, parts=parts, msaa=msaa)
     for spec, out_path in zip(view_specs, output_paths):
         if isinstance(spec, str):
             view.SetProj(VIEWS[spec])
@@ -209,7 +222,7 @@ def render_shape_batch(shape, view_specs, output_paths, width=512, height=512, p
             view.SetUp(0, 0, 1)
         view.FitAll()
         view.Redraw()
-        _capture(view, out_path, width, height)
+        _capture(view, out_path, width, height, msaa=msaa)
 
 
 # The default composite is one top-down layout view + three iso angles spaced
@@ -356,7 +369,8 @@ def render_diff_side_by_side(shape_a, shape_b, label_a, label_b, output_path,
 
 
 def render_shape_custom(shape, azimuth, elevation, output_path,
-                        width=800, height=600, zoom=1.0, focus=None, fit=True, parts=None):
+                        width=800, height=600, zoom=1.0, focus=None, fit=True,
+                        parts=None, msaa=0):
     """Render a TopoDS_Shape to a PNG file from a custom azimuth/elevation angle."""
     az = math.radians(azimuth)
     el = math.radians(elevation)
@@ -365,13 +379,13 @@ def render_shape_custom(shape, azimuth, elevation, output_path,
     vy = math.cos(az) * math.cos(el)
     vz = -math.sin(el)
 
-    view, _ctx = _setup_render(shape, width, height, parts=parts)
+    view, _ctx = _setup_render(shape, width, height, parts=parts, msaa=msaa)
 
     view.SetProj(vx, vy, vz)
     view.SetUp(0, 0, 1)
     _apply_camera(view, zoom, focus, fit)
 
-    _capture(view, output_path, width, height)
+    _capture(view, output_path, width, height, msaa=msaa)
 
 
 def render_views(shape, view_names, output_dir):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,11 +1,14 @@
 from pathlib import Path
 
 import cadquery as cq
+from PIL import Image, ImageChops
 
 import pytest
 
 from agentcad.render import (
+    _setup_render,
     render_shape,
+    render_shape_batch,
     render_shape_custom,
     render_views,
     parse_view_spec,
@@ -25,6 +28,35 @@ def test_render_shape_produces_png(tmp_path):
     render_shape(shape, "iso", out)
     assert out.exists()
     assert out.stat().st_size > 0
+
+
+def test_render_shape_supports_custom_size_and_msaa(tmp_path):
+    shape = _make_box_shape()
+    aliased = tmp_path / "aliased.png"
+    antialiased = tmp_path / "antialiased.png"
+    render_shape(shape, "iso", aliased, width=320, height=240)
+    render_shape(shape, "iso", antialiased, width=320, height=240, msaa=8)
+    with Image.open(antialiased) as image:
+        assert image.size == (320, 240)
+    with Image.open(aliased) as before, Image.open(antialiased) as after:
+        assert ImageChops.difference(before, after).getbbox() is not None
+
+
+def test_setup_render_configures_msaa_samples():
+    shape = _make_box_shape()
+    view, _context = _setup_render(shape, width=64, height=64, msaa=8)
+    assert view.ChangeRenderingParams().NbMsaaSamples == 8
+
+
+def test_render_shape_batch_supports_msaa(tmp_path):
+    shape = _make_box_shape()
+    outputs = [tmp_path / "front.png", tmp_path / "iso.png"]
+    render_shape_batch(
+        shape, ["front", "iso"], outputs, width=160, height=120, msaa=4,
+    )
+    for output in outputs:
+        with Image.open(output) as image:
+            assert image.size == (160, 120)
 
 
 def test_render_shape_iso_view(tmp_path):

--- a/tests/test_render_cmd.py
+++ b/tests/test_render_cmd.py
@@ -1,6 +1,8 @@
 import json
 from pathlib import Path
 
+from PIL import Image
+
 from agentcad.cli import cli
 
 
@@ -60,6 +62,89 @@ def test_render_produces_png(runner, isolated_dir):
     png_path = Path(parsed["renders"]["iso"])
     assert png_path.exists()
     assert png_path.read_bytes()[:4] == b"\x89PNG"
+
+
+def test_render_defaults_to_800_by_600(runner, isolated_dir):
+    step_path = _create_standalone_step(isolated_dir)
+    result = runner.invoke(cli, ["render", str(step_path), "--view", "iso", "--no-daemon"])
+    assert result.exit_code == 0, result.output
+    png_path = Path(json.loads(result.stdout)["renders"]["iso"])
+    with Image.open(png_path) as image:
+        assert image.size == (800, 600)
+
+
+def test_render_custom_size_and_msaa(runner, isolated_dir):
+    step_path = _create_standalone_step(isolated_dir)
+    result = runner.invoke(cli, [
+        "render", str(step_path), "--view", "45,30", "--size", "320x240",
+        "--msaa", "8", "--no-daemon",
+    ])
+    assert result.exit_code == 0, result.output
+    png_path = Path(json.loads(result.stdout)["renders"]["custom_45_30"])
+    with Image.open(png_path) as image:
+        assert image.size == (320, 240)
+
+
+def test_render_size_accepts_uppercase_separator(runner, isolated_dir):
+    step_path = _create_standalone_step(isolated_dir)
+    result = runner.invoke(cli, [
+        "render", str(step_path), "--view", "iso", "--size", "160X120",
+        "--no-daemon",
+    ])
+    assert result.exit_code == 0, result.output
+    png_path = Path(json.loads(result.stdout)["renders"]["iso"])
+    with Image.open(png_path) as image:
+        assert image.size == (160, 120)
+
+
+def test_render_rejects_invalid_size(runner, isolated_dir):
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--size", "800x0",
+    ])
+    assert result.exit_code == 2
+    assert "width and height must be positive" in result.output
+
+
+def test_render_rejects_malformed_and_negative_sizes(runner, isolated_dir):
+    for size in ("800", "800*600", "-1x600"):
+        result = runner.invoke(cli, [
+            "render", "any.step", "--view", "iso", "--size", size,
+        ])
+        assert result.exit_code == 2
+        assert "expected WIDTHxHEIGHT" in result.output
+
+
+def test_render_rejects_excessive_size(runner, isolated_dir):
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--size", f"{'9' * 5000}x600",
+    ])
+    assert result.exit_code == 2
+    assert "must not exceed 8192 pixels" in result.output
+
+
+def test_render_rejects_excessive_antialiased_size(runner, isolated_dir):
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--size", "4096x4096",
+        "--msaa", "8",
+    ])
+    assert result.exit_code == 2
+    assert "antialiased output size must not exceed 9 million pixels" in result.output
+
+
+def test_render_rejects_msaa_above_limit(runner, isolated_dir):
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--msaa", "32",
+    ])
+    assert result.exit_code == 2
+    assert "32 is not in the range 0<=x<=16" in result.output
+
+
+def test_render_rejects_negative_msaa(runner, isolated_dir):
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--msaa", "-1",
+    ])
+    assert result.exit_code == 2
+    assert "-1 is not in the range 0<=x<=16" in result.output
 
 
 def test_render_multiple_views(runner, isolated_dir):
@@ -247,6 +332,34 @@ def test_render_routes_through_daemon_when_available(runner, isolated_dir, monke
     parsed = json.loads(result.stdout)
     assert parsed["via"] == "daemon"
     assert parsed["command"] == "render"
+
+
+def test_render_forwards_size_and_msaa_to_daemon(runner, isolated_dir, monkeypatch):
+    monkeypatch.delenv("AGENTCAD_DAEMON", raising=False)
+    requests = []
+
+    def _capture(request, **_kwargs):
+        requests.append(request)
+        return {
+            "type": "result",
+            "exit_code": 0,
+            "output": json.dumps({
+                "command": "render",
+                "status": "success",
+                "renders": {"iso": "iso.png"},
+            }),
+        }
+
+    monkeypatch.setattr("agentcad.daemon.send_request", _capture)
+    result = runner.invoke(cli, [
+        "render", "any.step", "--view", "iso", "--size", "2400x1800",
+        "--msaa", "8",
+    ])
+    assert result.exit_code == 0, result.output
+    assert requests[0]["argv"] == [
+        "render", "any.step", "--view", "iso", "--size", "2400x1800",
+        "--msaa", "8",
+    ]
 
 
 def test_render_direct_no_via_field(runner, isolated_dir):


### PR DESCRIPTION
## Summary

- add `--size WIDTHxHEIGHT` and `--msaa 0..16` to `agentcad render` while preserving the 800x600, no-antialiasing defaults
- propagate resolution and antialiasing through named, custom, batch, and daemon-routed render paths
- ensure antialiasing works under offscreen/software GL with 2x supersampling and downsampling, plus bounded input validation
- update CLI/docs and add focused regression coverage

## Validation

- `pytest -q`: 1080 passed, 2 skipped
- focused render suites after final hardening: 63 passed
- independent sub-agent friction run and follow-up recheck completed
- `git diff --check`

Closes #53