### PR TITLE
fix: report installed package version in tool metadata

### DIFF
--- a/src/agentcad/commands/context.py
+++ b/src/agentcad/commands/context.py
@@ -2,9 +2,13 @@ import json
 
 import click
 
+from agentcad import __version__
 from agentcad.manifest import load_manifest
 
-TOOL_VERSION = "0.1.0"
+# The tool version reported in command metadata tracks the installed package
+# version (agentcad.__version__), falling back to "0.0.0+source" in an
+# un-installed checkout. import_cmd re-exports this for imported-version meta.
+TOOL_VERSION = __version__
 
 
 @click.command()

--- a/src/agentcad/commands/init.py
+++ b/src/agentcad/commands/init.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import click
 
+from agentcad import __version__
 from agentcad.manifest import MANIFEST_FILE
 
 
@@ -60,7 +61,7 @@ def init(name, runtime, force):
 def _build_manifest(project_name: str, runtime: str | None) -> dict:
     manifest = {
         "name": project_name,
-        "version": "0.1.0",
+        "version": __version__,
         "created": datetime.now(timezone.utc).isoformat(),
         "versions": [],
     }

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,7 @@
 import json
 
 from click.testing import CliRunner
+from agentcad import __version__
 from agentcad.cli import cli
 
 
@@ -82,4 +83,4 @@ def test_context_includes_tool_version(runner, isolated_dir):
     result = runner.invoke(cli, ["context"])
     data = json.loads(result.stdout)
     assert "tool_version" in data
-    assert data["tool_version"] == "0.1.0"
+    assert data["tool_version"] == __version__

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -13,6 +13,7 @@ import cadquery as cq
 import pytest
 from cadquery import exporters
 
+from agentcad import __version__
 from agentcad.cli import cli
 
 
@@ -99,7 +100,7 @@ class TestImportCore:
         assert meta["source"] == "import"
         assert meta["original_filename"] == "bracket.step"
         assert meta["sha256"] == original_sha
-        assert "tool_version" in meta
+        assert meta["tool_version"] == __version__
 
     def test_manifest_entry_marks_source_as_import(self, runner, isolated_dir):
         _init_project(runner, isolated_dir)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 import json
 from datetime import datetime
 
+from agentcad import __version__
 from agentcad.cli import cli
 from agentcad.commands.init import MANIFEST_FILE
 
@@ -16,7 +17,7 @@ def test_init_manifest_has_correct_schema(runner, isolated_dir):
     assert "name" in manifest
     assert "created" in manifest
     assert "version" in manifest
-    assert manifest["version"] == "0.1.0"
+    assert manifest["version"] == __version__
 
 
 def test_init_default_project_name_is_directory_name(runner, isolated_dir):


### PR DESCRIPTION
## Problem

`init`, `context`, and `import` reported a hardcoded `"0.1.0"` tool/manifest version even though the package is at `0.4.0` and `agentcad.__version__` already resolves the installed version:

- `init.py` wrote `manifest["version"] = "0.1.0"`
- `context.py` defined `TOOL_VERSION = "0.1.0"`
- `import_cmd.py` re-exports that `TOOL_VERSION` into imported `meta.json`

So the metadata could go stale on every release.

## Change

- `init`: `manifest["version"]` now uses `agentcad.__version__`.
- `context`: `TOOL_VERSION` now derives from `agentcad.__version__`; since `import_cmd` imports it from here, imported `meta.json.tool_version` follows automatically.
- The `__init__` fallback (`0.0.0+source`) is preserved for un-installed source checkouts.
- No public response shape changed — only the value.

Verified manually (installed 0.4.0):
```
$ agentcad init  → agentcad.json version: 0.4.0
$ agentcad context → tool_version: 0.4.0
```

## Tests

Updated the tests that pinned `"0.1.0"` to assert against `__version__`:
- `test_init.py::test_init_manifest_has_correct_schema`
- `test_context.py::test_context_includes_tool_version`
- `test_import.py` — tightened `"tool_version" in meta` to `== __version__`

`pytest tests/test_init.py tests/test_context.py` → 15 passed. (`test_import.py` runs under the CadQuery kernel, which isn't installed in my local env — it's covered by CI; the change there is a strict tightening of an existing assertion.)

Closes #60