### PR TITLE
fix: preserve at-most-once daemon execution

### DIFF
--- a/src/agentcad/commands/_daemon_routing.py
+++ b/src/agentcad/commands/_daemon_routing.py
@@ -51,9 +51,11 @@ def _pid_path() -> str:
 
 def _route_through_daemon(argv: list[str]):
     """Send an argv-shaped request to the daemon. Returns the raw response
-    dict, or ``None`` if the daemon couldn't be reached. argv[0] is the
-    Click subcommand name (``run``, ``render``, etc.); the daemon-side
-    handler invokes the CLI with this argv directly."""
+    dict, or ``None`` only if the daemon couldn't be reached before request
+    submission. A timeout/disconnect after submission is returned as an
+    explicit nonzero result so the caller never repeats non-idempotent work.
+    argv[0] is the Click subcommand name (``run``, ``render``, etc.); the
+    daemon-side handler invokes the CLI with this argv directly."""
     return _daemon.send_request(
         {"type": "run", "cwd": str(Path.cwd()), "argv": argv},
         socket_path=_socket_path(),
@@ -71,8 +73,10 @@ def maybe_route_through_daemon(argv: list[str], no_daemon: bool = False) -> None
         would recurse),
       * the daemon is unreachable.
 
-    On successful routing, prints the (possibly augmented) output on
-    stdout and calls ``sys.exit(exit_code)`` — caller never returns.
+    On successful routing, or when a submitted request's outcome is unknown,
+    prints the (possibly augmented) output on stdout and calls
+    ``sys.exit(exit_code)`` — caller never returns. Direct execution is only
+    safe when ``send_request`` returns ``None`` before submission.
 
     Pip-upgrade hint: a daemon started before ``pip install --upgrade
     agentcad`` keeps the old code in memory. We don't auto-restart it

--- a/src/agentcad/daemon.py
+++ b/src/agentcad/daemon.py
@@ -372,22 +372,106 @@ def _run_in_child(server, request, conn):
 
 # ---------- Client ----------
 
-def send_request(msg, socket_path=None):
-    """Send a request to the daemon and return the response, or None if unavailable."""
-    if socket_path is None:
-        socket_path = _default_socket_path()
+_DEFAULT_CONNECT_TIMEOUT_S = 1.0
+_DEFAULT_RESPONSE_TIMEOUT_S = 30.0
+_UNKNOWN_OUTCOME_EXIT_CODE = 124
 
-    try:
-        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-        sock.settimeout(30)
-        sock.connect(socket_path)
-    except (FileNotFoundError, ConnectionRefusedError, OSError):
+
+def _unknown_run_outcome(msg, *, timed_out):
+    """Return a routed error when a submitted run's result is unknowable.
+
+    Once socket submission begins, falling back to direct execution is unsafe:
+    the daemon child may still be running and both copies could allocate the
+    same version or write the same artifacts. Operational requests keep their
+    historical ``None`` result on transport failure; only non-idempotent
+    CLI requests need the explicit at-most-once response.
+    """
+    if msg.get("type") != "run":
         return None
 
+    argv = msg.get("argv") or []
+    command = argv[0] if argv else "unknown"
+    error_kind = (
+        "daemon_response_timeout" if timed_out
+        else "daemon_response_lost"
+    )
+    return {
+        "type": "result",
+        "exit_code": _UNKNOWN_OUTCOME_EXIT_CODE,
+        "output": json.dumps({
+            "command": command,
+            "status": "error",
+            "error_kind": error_kind,
+            "request_submitted": True,
+            "outcome": "unknown",
+            "retry_safe": False,
+            "message": (
+                "The daemon request was submitted, but its response was not "
+                "received. The command may still be running and was not "
+                "retried locally."
+            ),
+            "suggestion": (
+                "Check the project outputs and `agentcad daemon status` "
+                "before deciding whether to retry."
+            ),
+        }),
+        "stderr": "",
+    }
+
+
+def send_request(
+    msg,
+    socket_path=None,
+    *,
+    connect_timeout_s=None,
+    response_timeout_s=None,
+):
+    """Send one request and return its response.
+
+    ``None`` means the daemon could not be reached before submission, so CLI
+    callers may safely execute directly. A ``run`` failure after submission
+    begins returns a nonzero ``result`` with ``outcome=unknown`` instead; the
+    caller must not retry a non-idempotent command automatically.
+
+    Connect and response deadlines are separate and injectable so regression
+    tests can exercise slow responses without waiting 30 seconds.
+    """
+    if socket_path is None:
+        socket_path = _default_socket_path()
+    if connect_timeout_s is None:
+        connect_timeout_s = _DEFAULT_CONNECT_TIMEOUT_S
+    if response_timeout_s is None:
+        response_timeout_s = _DEFAULT_RESPONSE_TIMEOUT_S
+
+    sock = None
     try:
-        sock.sendall(encode_message(msg))
-        return _read_one_message(sock)
-    except (ConnectionError, OSError):
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        sock.settimeout(connect_timeout_s)
+        sock.connect(socket_path)
+    except (FileNotFoundError, ConnectionRefusedError, OSError):
+        if sock is not None:
+            _safe_close(sock)
+        return None
+
+    submission_started = False
+    try:
+        payload = encode_message(msg)
+        sock.settimeout(response_timeout_s)
+        # From this point onward, any send/read failure has an uncertain
+        # outcome. ``sendall`` can raise after writing only part of a frame,
+        # so conservatively suppress direct fallback as soon as it begins.
+        submission_started = True
+        sock.sendall(payload)
+        response = _read_one_message(sock)
+        if response is None:
+            return _unknown_run_outcome(msg, timed_out=False)
+        return response
+    except (ConnectionError, OSError) as exc:
+        if submission_started:
+            return _unknown_run_outcome(
+                msg,
+                timed_out=isinstance(exc, TimeoutError),
+            )
         return None
     finally:
         _safe_close(sock)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -23,6 +23,41 @@ def _short_pid_path(name):
     return f"/tmp/agentcad-test-{name}-{os.getpid()}.pid"
 
 
+def _start_slow_request_server(name, delay_s=0.15):
+    """Accept one daemon frame, record its side effect, then stay silent."""
+    from agentcad.daemon import _read_one_message
+
+    sock_path = _short_sock_path(name)
+    if os.path.exists(sock_path):
+        os.unlink(sock_path)
+    listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    listener.bind(sock_path)
+    listener.listen(1)
+    listener.settimeout(2)
+    submissions = []
+    errors = []
+
+    def _serve():
+        try:
+            conn, _ = listener.accept()
+            try:
+                request = _read_one_message(conn)
+                submissions.append(request)
+                time.sleep(delay_s)
+            finally:
+                conn.close()
+        except Exception as exc:
+            errors.append(exc)
+        finally:
+            listener.close()
+            if os.path.exists(sock_path):
+                os.unlink(sock_path)
+
+    thread = threading.Thread(target=_serve, daemon=True)
+    thread.start()
+    return sock_path, thread, submissions, errors
+
+
 # ---------- Phase 1: Protocol ----------
 
 class TestProtocol:
@@ -105,6 +140,69 @@ class TestSendRequest:
         finally:
             if os.path.exists(sock_path):
                 os.unlink(sock_path)
+
+    def test_run_timeout_after_submission_returns_unknown_outcome(self):
+        """A response timeout is not equivalent to daemon unavailability.
+
+        The server has already observed the request side effect, so returning
+        ``None`` here would cause the CLI to repeat non-idempotent work.
+        """
+        from agentcad.daemon import send_request
+
+        sock_path, thread, submissions, errors = _start_slow_request_server(
+            "uncertain-timeout"
+        )
+        response = send_request(
+            {
+                "type": "run",
+                "cwd": "/tmp",
+                "argv": ["run", "slow.py", "--output", "slow"],
+            },
+            socket_path=sock_path,
+            response_timeout_s=0.03,
+        )
+        thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert len(submissions) == 1
+        assert response is not None
+        assert response["exit_code"] != 0
+        payload = json.loads(response["output"])
+        assert payload["error_kind"] == "daemon_response_timeout"
+        assert payload["request_submitted"] is True
+        assert payload["outcome"] == "unknown"
+        assert payload["retry_safe"] is False
+
+    def test_run_eof_after_submission_returns_unknown_outcome(self):
+        """A daemon disconnect after reading the request is also unsafe to
+        retry because the child may have completed its side effects."""
+        from agentcad.daemon import send_request
+
+        sock_path, thread, submissions, errors = _start_slow_request_server(
+            "uncertain-eof", delay_s=0
+        )
+        response = send_request(
+            {
+                "type": "run",
+                "cwd": "/tmp",
+                "argv": ["render", "part.step"],
+            },
+            socket_path=sock_path,
+            response_timeout_s=1,
+        )
+        thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert len(submissions) == 1
+        assert response is not None
+        assert response["exit_code"] != 0
+        payload = json.loads(response["output"])
+        assert payload["error_kind"] == "daemon_response_lost"
+        assert payload["request_submitted"] is True
+        assert payload["outcome"] == "unknown"
+        assert payload["retry_safe"] is False
 
 
 # ---------- Phase 2: Server handlers ----------
@@ -586,9 +684,24 @@ class TestRunRouting:
         send_request({"type": "shutdown"}, socket_path=sock_path)
         t.join(timeout=5)
 
-    def test_run_fallback_when_daemon_not_running(self, runner, isolated_dir):
+    def test_run_fallback_when_daemon_not_running(
+        self, runner, isolated_dir, monkeypatch
+    ):
         """agentcad run still works when daemon is not running."""
         from agentcad.cli import cli
+
+        monkeypatch.delenv("AGENTCAD_DAEMON", raising=False)
+        missing_socket = _short_sock_path("fallback-missing")
+        if os.path.exists(missing_socket):
+            os.unlink(missing_socket)
+        monkeypatch.setattr(
+            "agentcad.commands._daemon_routing._socket_path",
+            lambda: missing_socket,
+        )
+        monkeypatch.setattr(
+            "agentcad.daemon.spawn_daemon_via_fork",
+            lambda **kwargs: {"spawned": False, "reason": "test"},
+        )
 
         runner.invoke(cli, ["init", "--name", "test"])
         script = isolated_dir / "box.py"
@@ -598,6 +711,56 @@ class TestRunRouting:
         assert result.exit_code == 0
         output = json.loads(result.stdout)
         assert output["status"] == "success"
+
+    def test_submitted_timeout_is_not_retried_directly(
+        self, runner, isolated_dir, monkeypatch
+    ):
+        """A silent daemon receives the request once; the CLI must stop with
+        an unknown-outcome error instead of executing the script locally."""
+        from agentcad.cli import cli
+
+        monkeypatch.delenv("AGENTCAD_DAEMON", raising=False)
+        sock_path, thread, submissions, errors = _start_slow_request_server(
+            "routing-timeout"
+        )
+        monkeypatch.setattr(
+            "agentcad.commands._daemon_routing._socket_path",
+            lambda: sock_path,
+        )
+        monkeypatch.setattr(
+            "agentcad.daemon._DEFAULT_RESPONSE_TIMEOUT_S",
+            0.03,
+        )
+
+        runner.invoke(cli, ["init", "--name", "test"])
+        direct_marker = isolated_dir / "direct-execution.txt"
+        script = isolated_dir / "slow.py"
+        script.write_text(
+            "from pathlib import Path\n"
+            "import cadquery as cq\n"
+            f"Path({str(direct_marker)!r}).write_text('ran directly')\n"
+            "show_object(cq.Workplane('XY').box(1, 1, 1))\n"
+        )
+
+        result = runner.invoke(
+            cli,
+            ["run", str(script), "--output", "slow", "--no-preview"],
+        )
+        thread.join(timeout=2)
+
+        assert not thread.is_alive()
+        assert errors == []
+        assert len(submissions) == 1
+        assert not direct_marker.exists(), (
+            "the submitted request timed out and was executed again locally"
+        )
+        assert result.exit_code == 124
+        payload = json.loads(result.stdout)
+        assert payload["status"] == "error"
+        assert payload["error_kind"] == "daemon_response_timeout"
+        assert payload["outcome"] == "unknown"
+        assert payload["retry_safe"] is False
+        assert payload["via"] == "daemon"
 
     def test_run_routing_uses_daemon_when_available(self, isolated_dir, daemon_paths, monkeypatch):
         """agentcad run routes through daemon when it is running."""


### PR DESCRIPTION
## Summary

- distinguish daemon connection failure before request submission from response failure after submission
- allow safe direct fallback only before submission begins
- return a structured, nonzero `outcome: unknown` result after timeout, disconnect, or send failure so non-idempotent commands are never retried locally
- separate connect and response deadlines and make them injectable for fast regression coverage
- cover timeout, EOF, pre-submit fallback, and a side-effect marker proving at-most-once routing

## Response contract

When the daemon request may still be running but its response is unavailable, the CLI exits `124` and reports:

```json
{
  "status": "error",
  "error_kind": "daemon_response_timeout",
  "request_submitted": true,
  "outcome": "unknown",
  "retry_safe": false,
  "via": "daemon"
}
```

## Testing

- `.venv/bin/pytest -q` — 1092 passed, 2 skipped
- focused daemon/routing checks — 17 passed
- `git diff --check`

Closes #69
