### PR TITLE
fix: validate --render spec early in agentcad run

### DIFF
--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -527,6 +527,19 @@ def _run_impl(ctx, script, output, render, export, preview, params,
                 "message": str(e),
             }))
             sys.exit(1)
+
+    # Validate --render spec before version allocation (errors should be cheap)
+    if render:
+        from agentcad.render import parse_view_spec as _parse_view_spec
+        try:
+            _parse_view_spec(render)
+        except ValueError as e:
+            click.echo(json.dumps({
+                "command": "run",
+                "status": "error",
+                "message": str(e),
+            }))
+            sys.exit(1)
     _finish_phase("validation", _t, "validation_ms")
 
     # Spawn the daemon NOW — after the runner module is imported (so OCP is

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -458,6 +458,41 @@ def test_run_without_render_no_renders_key(runner, isolated_dir):
     assert "renders" not in meta
 
 
+def test_run_invalid_render_spec_returns_clean_error(runner, isolated_dir):
+    """agentcad run --render <invalid> must fail fast with a clean JSON
+    error, not execute the script or leave an orphaned version directory."""
+    _init_project(runner)
+    _write_script(isolated_dir)
+    result = runner.invoke(
+        cli, ["run", "script.py", "--output", "label", "--render", "notaview"]
+    )
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "run"
+    assert parsed["status"] == "error"
+    assert "Invalid view spec" in parsed["message"]
+    assert "notaview" in parsed["message"]
+    assert "traceback" not in result.output.lower()
+    assert not (isolated_dir / "v1_label").exists()
+
+
+def test_run_invalid_render_spec_mixed_returns_clean_error(runner, isolated_dir):
+    """A bad token inside a mixed view spec (named + angle + bad) must also
+    fail fast with a clean JSON error before any disk writes."""
+    _init_project(runner)
+    _write_script(isolated_dir)
+    result = runner.invoke(
+        cli, ["run", "script.py", "--output", "label", "--render", "front,45:30,notaview"]
+    )
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "run"
+    assert parsed["status"] == "error"
+    assert "notaview" in parsed["message"]
+    assert "traceback" not in result.output.lower()
+    assert not (isolated_dir / "v1_label").exists()
+
+
 # --- Export integration tests ---
 
 


### PR DESCRIPTION
## Problem

`agentcad run --render <invalid>` (e.g. `--render foo` or `--render front,45:30,foo`) currently:

1. Executes the full CAD script
2. Writes a version directory (`vN_<label>/`) with `output.step`, mesh exports, `script.py`, etc.
3. **Crashes with a traceback** at render time (`parse_view_spec` raises `ValueError` at `run.py:728`)
4. Leaves an **orphaned version directory** on disk (manifest save is skipped because the error path exits before it)

The user/agent gets a scary `"Internal error: ValueError: ..."` + full Python traceback instead of an actionable message, and the typo'd view name is buried in the traceback string.

## Root cause

`parse_view_spec(render)` is called at `run.py:728` with **no error handling**, late in the flow — after version allocation and disk writes, but before the manifest is saved. This is inconsistent with two existing validation paths:

- The standalone `agentcad render --view` already validates cleanly (`render.py:138-146`: try/except `ValueError` -> clean JSON error -> `sys.exit(1)`)
- `agentcad run --params` is validated **early** in the validation phase with a clean JSON error (`run.py:518-529`)

## Fix

Add early validation of the `--render` spec in the **validation phase** (immediately after the existing `--params` block, before version allocation and any disk writes), mirroring both of the above patterns exactly:

```python
if render:
    from agentcad.render import parse_view_spec as _parse_view_spec
    try:
        _parse_view_spec(render)
    except ValueError as e:
        click.echo(json.dumps({
            "command": "run",
            "status": "error",
            "message": str(e),
        }))
        sys.exit(1)
```

Now an invalid `--render` value fails fast with the same clean JSON error shape every other input-validation path returns, before any disk writes:

```
$ agentcad run script.py --output t --render notaview
{"command": "run", "status": "error", "message": "Invalid view spec 'notaview'. Use named views (back, bottom, front, iso, left, right, top), 'all', or 'azimuth:elevation'."}
```

No `vN_t/` directory is created, no script is executed.

## Tests

Two tests in `tests/test_run.py`:

- `test_run_invalid_render_spec_returns_clean_error` — single invalid token (`notaview`): asserts exit 1, clean JSON, `"Invalid view spec"` + `"notaview"` in message, no traceback in output, no orphaned `v1_label` directory.
- `test_run_invalid_render_spec_mixed_returns_clean_error` — bad token inside a mixed spec (`front,45:30,notaview`, which exercises a distinct code path in `parse_view_spec` producing a different error message): asserts exit 1, clean JSON, `"notaview"` in message, no traceback, no orphaned directory.

Both tests fail fast in the validation phase before the rendering pipeline, so they don't require an X display.

## Scope

Small, self-contained change: +13 lines production, +35 lines tests. No changes to valid `--render` behavior (any spec that passed the late `parse_view_spec` call also passes the early one — same pure function).