### PR TITLE
fix: bound daemon protocol reads

### DIFF
--- a/src/agentcad/daemon.py
+++ b/src/agentcad/daemon.py
@@ -96,6 +96,16 @@ def _default_pid_path():
 
 # ---------- Protocol ----------
 
+_MAX_REQUEST_PAYLOAD_BYTES = 1024 * 1024
+_MAX_RESPONSE_PAYLOAD_BYTES = 64 * 1024 * 1024
+_REQUEST_READ_TIMEOUT_S = 1.0
+_STATUS_PING_TIMEOUT_S = 2.0
+
+
+class DaemonProtocolError(Exception):
+    """A peer sent a frame that violates the daemon protocol contract."""
+
+
 def encode_message(msg):
     """Encode a dict as length-prefixed JSON (4-byte big-endian uint32 + UTF-8)."""
     payload = json.dumps(msg).encode("utf-8")
@@ -254,7 +264,11 @@ class DaemonServer:
                 except socket.timeout:
                     continue
                 try:
-                    request = _read_one_message(conn)
+                    request = _read_one_message(
+                        conn,
+                        timeout_s=_REQUEST_READ_TIMEOUT_S,
+                        max_payload_bytes=_MAX_REQUEST_PAYLOAD_BYTES,
+                    )
                 except Exception:
                     _safe_close(conn)
                     continue
@@ -318,20 +332,61 @@ class DaemonServer:
             _safe_close(conn)
 
 
-def _read_one_message(conn):
+def _read_one_message(conn, *, timeout_s=None, max_payload_bytes=None):
     """Block until one length-prefixed JSON message arrives on ``conn``.
 
-    Returns the decoded dict or None on EOF. Raises on socket error.
+    ``timeout_s`` is an absolute frame deadline, not a per-recv inactivity
+    timeout, so a peer cannot hold the reader forever by dripping bytes. The
+    declared payload length is rejected before body accumulation when it
+    exceeds ``max_payload_bytes``.
+
+    Returns the decoded dict or None on EOF. Raises on socket/protocol error.
     """
-    buf = b""
-    while True:
-        chunk = conn.recv(65536)
-        if not chunk:
-            return None
-        buf += chunk
-        request, _ = decode_message(buf)
-        if request is not None:
-            return request
+    buf = bytearray()
+    declared_length = None
+    deadline = None if timeout_s is None else time.monotonic() + timeout_s
+    original_timeout = conn.gettimeout()
+
+    try:
+        while True:
+            if declared_length is None and len(buf) >= 4:
+                declared_length = struct.unpack("!I", buf[:4])[0]
+                if (
+                    max_payload_bytes is not None
+                    and declared_length > max_payload_bytes
+                ):
+                    raise DaemonProtocolError(
+                        f"daemon frame payload {declared_length} exceeds "
+                        f"limit {max_payload_bytes}"
+                    )
+
+            if declared_length is not None:
+                total_length = 4 + declared_length
+                if len(buf) >= total_length:
+                    try:
+                        message, _ = decode_message(bytes(buf))
+                        return message
+                    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                        raise DaemonProtocolError(
+                            "daemon frame payload is not valid UTF-8 JSON"
+                        ) from exc
+                recv_size = min(65536, total_length - len(buf))
+            else:
+                recv_size = 4 - len(buf)
+
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise socket.timeout("daemon frame read timed out")
+                conn.settimeout(remaining)
+
+            chunk = conn.recv(recv_size)
+            if not chunk:
+                return None
+            buf.extend(chunk)
+    finally:
+        if timeout_s is not None:
+            conn.settimeout(original_timeout)
 
 
 def _safe_close(sock):
@@ -377,17 +432,22 @@ _DEFAULT_RESPONSE_TIMEOUT_S = 30.0
 _UNKNOWN_OUTCOME_EXIT_CODE = 124
 
 
-def _unknown_run_outcome(msg, *, timed_out):
-    """Return a routed error when a submitted run's result is unknowable.
+def _post_submission_failure(msg, *, timed_out):
+    """Describe a transport failure after request submission has begun.
 
     Once socket submission begins, falling back to direct execution is unsafe:
     the daemon child may still be running and both copies could allocate the
-    same version or write the same artifacts. Operational requests keep their
-    historical ``None`` result on transport failure; only non-idempotent
-    CLI requests need the explicit at-most-once response.
+    same version or write the same artifacts. Non-idempotent CLI requests get
+    an explicit at-most-once result; operational requests get an internal
+    transport marker so status checks can distinguish an accepted-but-silent
+    listener from a missing listener.
     """
     if msg.get("type") != "run":
-        return None
+        return {
+            "type": "transport_error",
+            "phase": "response",
+            "timed_out": timed_out,
+        }
 
     argv = msg.get("argv") or []
     command = argv[0] if argv else "unknown"
@@ -431,7 +491,8 @@ def send_request(
     ``None`` means the daemon could not be reached before submission, so CLI
     callers may safely execute directly. A ``run`` failure after submission
     begins returns a nonzero ``result`` with ``outcome=unknown`` instead; the
-    caller must not retry a non-idempotent command automatically.
+    caller must not retry a non-idempotent command automatically. Operational
+    requests return an internal ``transport_error`` marker after submission.
 
     Connect and response deadlines are separate and injectable so regression
     tests can exercise slow responses without waiting 30 seconds.
@@ -462,13 +523,17 @@ def send_request(
         # so conservatively suppress direct fallback as soon as it begins.
         submission_started = True
         sock.sendall(payload)
-        response = _read_one_message(sock)
+        response = _read_one_message(
+            sock,
+            timeout_s=response_timeout_s,
+            max_payload_bytes=_MAX_RESPONSE_PAYLOAD_BYTES,
+        )
         if response is None:
-            return _unknown_run_outcome(msg, timed_out=False)
+            return _post_submission_failure(msg, timed_out=False)
         return response
-    except (ConnectionError, OSError) as exc:
+    except (ConnectionError, OSError, DaemonProtocolError) as exc:
         if submission_started:
-            return _unknown_run_outcome(
+            return _post_submission_failure(
                 msg,
                 timed_out=isinstance(exc, TimeoutError),
             )
@@ -526,15 +591,15 @@ def daemon_status(socket_path=None, pid_path=None):
     and (when relevant) a ``stale`` flag + hint when the daemon's in-memory
     code is older than the installed agentcad on disk.
 
-    Requires successful ping, not just an alive PID. The pid file by itself
-    can lie — a leftover from a dead daemon could point at an unrelated
-    alive process (e.g. an ``agentcad render`` from another shell, or PID
-    recycling after the original daemon was SIGKILLed), which would
-    otherwise falsely report ``running:true`` and block
-    ``spawn_daemon_via_fork`` from starting a fresh daemon. Issue #190.
+    Uses ping, not just an alive PID, to confirm a responsive daemon. The pid
+    file by itself can lie — a leftover from a dead daemon could point at an
+    unrelated alive process (e.g. an ``agentcad render`` from another shell,
+    or PID recycling after the original daemon was SIGKILLed). A listener that
+    accepts the ping but misses the response deadline is reported as running
+    but unresponsive, and its ownership files are preserved for safe recovery.
 
-    Stale state (PID alive but socket unbound, or socket file present but
-    no listener answering ping) is cleaned up so the next spawn attempt
+    Stale state (PID alive but socket absent, or a socket pathname with no
+    listener accepting connections) is cleaned up so the next spawn attempt
     has a clean slate.
 
     The staleness check on the daemon's reported version is the only way
@@ -565,10 +630,27 @@ def daemon_status(socket_path=None, pid_path=None):
         _unlink_quiet(pid_path)
         return {"running": False}
 
-    # Probe the listener. Ping bypasses any state the daemon might be in;
-    # no response means this PID isn't actually a daemon (or the daemon
-    # is wedged) — clean up so spawn_daemon_via_fork can take over.
-    resp = send_request({"type": "ping"}, socket_path=socket_path)
+    # Probe the listener. A connection failure means there is no listener and
+    # the paths are stale. If the listener accepted our request but did not
+    # answer, preserve its ownership state: blindly unlinking a live endpoint
+    # can orphan the daemon and let a second parent bind the same pathname.
+    resp = send_request(
+        {"type": "ping"},
+        socket_path=socket_path,
+        response_timeout_s=_STATUS_PING_TIMEOUT_S,
+    )
+    if resp and resp.get("type") == "transport_error":
+        return {
+            "running": True,
+            "responsive": False,
+            "pid": pid,
+            "message": (
+                "Daemon process is alive and accepted the status probe, but "
+                "did not return a response. Its socket and PID state were "
+                "preserved; use `agentcad daemon restart` if it remains "
+                "unresponsive."
+            ),
+        }
     if not resp or resp.get("type") != "pong":
         _unlink_quiet(pid_path)
         _unlink_quiet(socket_path)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -115,6 +115,40 @@ class TestProtocol:
         assert decoded == original
         assert remainder == b""
 
+    def test_read_deadline_is_absolute_for_incomplete_header(self):
+        from agentcad.daemon import _read_one_message
+
+        reader, writer = socket.socketpair()
+        try:
+            writer.sendall(b"\x00")
+            started = time.monotonic()
+            with pytest.raises(socket.timeout):
+                _read_one_message(reader, timeout_s=0.03)
+            assert time.monotonic() - started < 0.5
+        finally:
+            reader.close()
+            writer.close()
+
+    def test_oversized_declared_payload_is_rejected_before_body_read(self):
+        from agentcad.daemon import (
+            DaemonProtocolError,
+            _MAX_REQUEST_PAYLOAD_BYTES,
+            _read_one_message,
+        )
+
+        reader, writer = socket.socketpair()
+        try:
+            writer.sendall(struct.pack("!I", _MAX_REQUEST_PAYLOAD_BYTES + 1))
+            with pytest.raises(DaemonProtocolError, match="exceeds limit"):
+                _read_one_message(
+                    reader,
+                    timeout_s=0.5,
+                    max_payload_bytes=_MAX_REQUEST_PAYLOAD_BYTES,
+                )
+        finally:
+            reader.close()
+            writer.close()
+
 
 # ---------- Phase 1: Client fallback ----------
 
@@ -537,6 +571,118 @@ class TestLifecycle:
 
         send_request({"type": "shutdown"}, socket_path=sock_path)
         t.join(timeout=5)
+
+
+class TestBoundedServerReads:
+    @staticmethod
+    def _start_server(sock_path, pid_path, monkeypatch):
+        from agentcad.daemon import DaemonServer
+
+        monkeypatch.setattr("agentcad.daemon._REQUEST_READ_TIMEOUT_S", 0.05)
+        server = DaemonServer(socket_path=sock_path, pid_path=pid_path)
+        thread = threading.Thread(target=server.serve)
+        thread.start()
+        for _ in range(100):
+            if os.path.exists(sock_path):
+                break
+            time.sleep(0.01)
+        assert os.path.exists(sock_path)
+        return thread
+
+    @pytest.mark.parametrize(
+        "partial_frame",
+        [
+            b"\x00",
+            struct.pack("!I", 100) + b"short",
+        ],
+        ids=["incomplete-header", "incomplete-body"],
+    )
+    def test_partial_frame_cannot_block_ping(
+        self, daemon_paths, monkeypatch, partial_frame
+    ):
+        from agentcad.daemon import send_request
+
+        sock_path, pid_path = daemon_paths
+        thread = self._start_server(sock_path, pid_path, monkeypatch)
+        blocker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            blocker.connect(sock_path)
+            blocker.sendall(partial_frame)
+
+            started = time.monotonic()
+            response = send_request(
+                {"type": "ping"},
+                socket_path=sock_path,
+                response_timeout_s=0.5,
+            )
+            elapsed = time.monotonic() - started
+
+            assert response["type"] == "pong"
+            assert elapsed < 0.5
+        finally:
+            blocker.close()
+            send_request({"type": "shutdown"}, socket_path=sock_path)
+            thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    def test_oversized_frame_is_rejected_and_server_recovers(
+        self, daemon_paths, monkeypatch
+    ):
+        from agentcad.daemon import (
+            _MAX_REQUEST_PAYLOAD_BYTES,
+            send_request,
+        )
+
+        sock_path, pid_path = daemon_paths
+        thread = self._start_server(sock_path, pid_path, monkeypatch)
+        attacker = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            attacker.connect(sock_path)
+            attacker.sendall(
+                struct.pack("!I", _MAX_REQUEST_PAYLOAD_BYTES + 1)
+            )
+            response = send_request(
+                {"type": "ping"},
+                socket_path=sock_path,
+                response_timeout_s=0.5,
+            )
+            assert response["type"] == "pong"
+        finally:
+            attacker.close()
+            send_request({"type": "shutdown"}, socket_path=sock_path)
+            thread.join(timeout=2)
+        assert not thread.is_alive()
+
+    def test_status_preserves_live_state_after_response_timeout(
+        self, monkeypatch
+    ):
+        from agentcad.daemon import daemon_status
+
+        sock_path, thread, submissions, errors = _start_slow_request_server(
+            "status-timeout", delay_s=0.15
+        )
+        pid_path = _short_pid_path("status-timeout")
+        with open(pid_path, "w") as f:
+            f.write(str(os.getpid()))
+        monkeypatch.setattr("agentcad.daemon._STATUS_PING_TIMEOUT_S", 0.03)
+        try:
+            result = daemon_status(
+                socket_path=sock_path,
+                pid_path=pid_path,
+            )
+
+            assert result["running"] is True
+            assert result["responsive"] is False
+            assert result["pid"] == os.getpid()
+            assert os.path.exists(sock_path)
+            assert os.path.exists(pid_path)
+            assert len(submissions) == 1
+        finally:
+            thread.join(timeout=2)
+            if os.path.exists(pid_path):
+                os.unlink(pid_path)
+        assert not thread.is_alive()
+        assert errors == []
 
 
 # ---------- Phase 4: CLI commands ----------


### PR DESCRIPTION
## Summary

- enforce an absolute deadline while reading daemon request frames
- reject oversized request frames before accumulating their bodies
- distinguish an accepted-but-unresponsive daemon from a missing listener so status does not unlink live ownership state
- add regressions for incomplete headers, incomplete bodies, oversized frames, recovery, and status timeout handling

## Validation

- `pytest tests/test_daemon.py -q` — 79 passed
- full repository suite — 1,098 passed, 2 skipped
- production-default black-box probe: a one-byte partial header released the accept loop after 1.001s; an oversized frame was rejected immediately; subsequent pings and shutdown succeeded; socket/PID cleanup completed

## Design note

This uses bounded synchronous reads. It prevents one partial client from monopolizing the daemon indefinitely and bounds per-frame memory, while keeping the existing fork-safe server architecture. Comprehensive coordinated multi-connection DoS resistance would require broader event-loop work.

Closes #72