### PR TITLE
Fix review cylinder marker placement

### DIFF
--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -1254,7 +1254,70 @@ function viewerBoundingBox() {
   };
 }
 
-function markerSurfacePosition(center, diameter, axis) {
+function markerLift(diameter) {
+  const markerDiameter = Number(diameter);
+  return Number.isFinite(markerDiameter) ? Math.max(markerDiameter * 0.003, 0.02) : 0.02;
+}
+
+function markerOutwardForAxis(key) {
+  const bbox = viewerBoundingBox();
+  const range = bbox[key] || null;
+  if (!Array.isArray(range) || range.length !== 2) return null;
+  const min = Number(range[0]);
+  const max = Number(range[1]);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+  const midpoint = (min + max) / 2;
+  return camera.position[key] >= midpoint ? 1 : -1;
+}
+
+function surfacePositionFromModel(center, diameter, axis) {
+  if (!reviewModelA) return null;
+  const key = viewerAxisKey(axis);
+  const bbox = viewerBoundingBox();
+  const range = bbox[key] || null;
+  if (!Array.isArray(range) || range.length !== 2) return null;
+  const min = Number(range[0]);
+  const max = Number(range[1]);
+  if (!Number.isFinite(min) || !Number.isFinite(max)) return null;
+
+  const outward = markerOutwardForAxis(key);
+  if (outward === null) return null;
+
+  const direction = new THREE.Vector3();
+  direction[key] = -outward;
+  const radialAxes = key === "x" ? ["y", "z"] : (key === "y" ? ["x", "z"] : ["x", "y"]);
+  const radius = Math.max(Number(diameter) / 2, 0.5);
+  const sampleRadius = radius * 1.05;
+  const base = cadPointToViewer(center);
+  const samples = [base.clone()];
+  for (let i = 0; i < 8; i++) {
+    const angle = (Math.PI * 2 * i) / 8;
+    const sample = base.clone();
+    sample[radialAxes[0]] += Math.cos(angle) * sampleRadius;
+    sample[radialAxes[1]] += Math.sin(angle) * sampleRadius;
+    samples.push(sample);
+  }
+
+  const hits = [];
+  const rayLength = Math.abs(max - min) + 2;
+  for (const sample of samples) {
+    const origin = sample.clone();
+    origin[key] = outward > 0 ? max + 1 : min - 1;
+    const raycaster = new THREE.Raycaster(origin, direction, 0, rayLength);
+    hits.push(...raycaster.intersectObject(reviewModelA, true));
+  }
+  if (!hits.length) return null;
+
+  hits.sort((a, b) => outward * (b.point[key] - a.point[key]));
+
+  const pos = hits[0].point.clone();
+  pos[radialAxes[0]] = base[radialAxes[0]];
+  pos[radialAxes[1]] = base[radialAxes[1]];
+  pos[key] += outward * markerLift(diameter);
+  return pos;
+}
+
+function fallbackMarkerSurfacePosition(center, diameter, axis) {
   const pos = cadPointToViewer(center);
   const key = viewerAxisKey(axis);
   const bbox = viewerBoundingBox();
@@ -1263,16 +1326,19 @@ function markerSurfacePosition(center, diameter, axis) {
     const min = Number(range[0]);
     const max = Number(range[1]);
     if (Number.isFinite(min) && Number.isFinite(max)) {
-      const midpoint = (min + max) / 2;
-      const cameraCoord = camera.position[key];
-      const outward = cameraCoord >= midpoint ? 1 : -1;
-      const face = outward > 0 ? max : min;
-      const markerDiameter = Number(diameter);
-      const offset = Number.isFinite(markerDiameter) ? Math.max(markerDiameter * 0.02, 0.06) : 0.06;
-      pos[key] = face + outward * offset;
+      const outward = markerOutwardForAxis(key);
+      if (outward !== null) {
+        const face = outward > 0 ? max : min;
+        pos[key] = face + outward * markerLift(diameter);
+      }
     }
   }
   return pos;
+}
+
+function markerSurfacePosition(center, diameter, axis) {
+  return surfacePositionFromModel(center, diameter, axis)
+    || fallbackMarkerSurfacePosition(center, diameter, axis);
 }
 
 function addRingMarker(center, diameter, axis, color, missing=false) {
@@ -1369,6 +1435,11 @@ function selectFirstReviewRow() {
   if (row) selectReviewRow(row, { focus: false });
 }
 
+function refreshActiveReviewMarkers() {
+  const row = document.querySelector("#spec-panel .review-row.active");
+  if (row) selectReviewRow(row, { focus: false });
+}
+
 // ---- Renderer + camera (shared across 3D modes) ----
 const canvas = document.getElementById('canvas');
 // preserveDrawingBuffer keeps the canvas readable for GIF export between
@@ -1426,6 +1497,7 @@ sceneA_single.add(reviewMarkerGroup);
 // Track loaded model meshes for overlay mode so UI can toggle visibility
 let overlayModelA = null;
 let overlayModelB = null;
+let reviewModelA = null;
 
 // Combined bounding box used to fit the camera globally
 const combinedBox = new THREE.Box3();
@@ -1478,7 +1550,13 @@ function fitCamera() {
 // Load all scenes in parallel, then fit camera
 Promise.all([
   attach(sceneA_single, MODEL_A_URL, {
-    onMesh: PARTS_MODEL === 'a' ? m => { registerPartMeshes(m); applyPartState(); } : null,
+    onMesh: m => {
+      reviewModelA = m;
+      if (PARTS_MODEL === 'a') {
+        registerPartMeshes(m);
+        applyPartState();
+      }
+    },
   }),
   hasB ? attach(sceneB_single, MODEL_B_URL, {
     onMesh: PARTS_MODEL === 'b' ? m => { registerPartMeshes(m); applyPartState(); } : null,
@@ -1490,6 +1568,7 @@ Promise.all([
 ].filter(Boolean)).then(() => {
   fitCamera();
   applyPartState();
+  refreshActiveReviewMarkers();
   if (partState.focus) focusPart(partState.focus);
   viewerReady = true;
   publishViewerDebugState();

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -289,6 +289,44 @@ def test_render_unified_embeds_review_payload(isolated_dir):
     assert 'DEFAULT_MODE = "spec"' in html
 
 
+def test_review_markers_use_model_surface_raycast(isolated_dir):
+    from agentcad.commands.view import _render_unified
+
+    glb = isolated_dir / "fake.glb"
+    glb.write_bytes(b"")
+    out = isolated_dir / "v.html"
+    review = {
+        "measure": {
+            "validity": {"is_valid": True},
+            "metrics": {
+                "dimensions": {"x": 50.0, "y": 20.0, "z": 5.0},
+                "bounding_box": {
+                    "x": [-25.0, 25.0],
+                    "y": [-10.0, 10.0],
+                    "z": [-2.5, 2.5],
+                },
+            },
+            "cylindrical_features": [
+                {
+                    "diameter_mm": 6.0,
+                    "count": 1,
+                    "axis": "+z",
+                    "representative_centers": [{"x": 0.0, "y": 0.0, "z": 0.0}],
+                }
+            ],
+        },
+        "check_spec": None,
+    }
+
+    _render_unified(out, glb_a=glb, label_a="x", default_mode="spec", review=review)
+
+    html = out.read_text()
+    assert "function surfacePositionFromModel" in html
+    assert "raycaster.intersectObject(reviewModelA, true)" in html
+    assert "fallbackMarkerSurfacePosition" in html
+    assert "reviewModelA = m" in html
+
+
 def test_view_step_with_spec_opens_spec_check_mode(runner, isolated_dir, monkeypatch):
     step = _make_two_hole_step(isolated_dir)
     spec = isolated_dir / "spec.json"


### PR DESCRIPTION
## Summary
- place cylinder review rings by raycasting against the loaded model surface instead of snapping to the global bounding-box face
- sample around the cylinder rim so through-holes still find nearby surface geometry
- refresh active review markers after the model loads and keep the existing bounding-box fallback
- add a viewer-template regression check for the raycast placement path

## Verification
- python3 -m py_compile src/agentcad/commands/view.py tests/test_view.py
- git diff --check

Note: pytest tests/test_view.py -q could not run in this workspace because the default Python environment is missing project dependencies such as click.