### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+- Describe the change and why it is needed.
+
+## Issue Link
+
+- Fixes #
+- Related to #
+- No issue; standalone bug found during use
+
+Keep one of the lines above and remove the others.
+
+## Validation
+
+- [ ] I ran the smallest meaningful test or manual repro.
+
+For `agentcad run` input-validation fixes, include coverage for:
+
+- [ ] clean JSON error
+- [ ] no traceback
+- [ ] no version directory or disk artifacts
+- [ ] no manifest version consumed


### PR DESCRIPTION
## Summary

Add a lightweight pull request template that asks contributors to link an issue or explicitly mark a standalone bug fix.

The template also captures the validation checklist we learned from PR #85 for `agentcad run` input-validation fixes: clean JSON errors, no traceback, no version artifacts, and no manifest version consumed.

## Validation

- `git diff --cached --check` before commit
- docs-only change; no code tests run