### PR TITLE
fix: export/run reject an effectively-empty format list

### DIFF
--- a/src/agentcad/commands/export_cmd.py
+++ b/src/agentcad/commands/export_cmd.py
@@ -27,6 +27,13 @@ def unsupported_export_formats(formats: str) -> list[str]:
     return [f for f in parse_export_formats(formats) if f not in VALID_FORMATS]
 
 
+# Shared so ``export`` and ``run --export`` report an all-blank format list
+# identically. Dropping blanks makes ``stl,`` trim cleanly, but when EVERY entry
+# is blank (``--format ","``) the result is an empty list, which would otherwise
+# export nothing and still report success.
+NO_FORMATS_MESSAGE = "No export formats specified. Supported: stl, glb, obj"
+
+
 def _is_version_dir(directory):
     """Check if directory matches v\\d+_\\w+ pattern and contains meta.json."""
     return bool(re.match(r"v\d+_\w+", directory.name)) and (directory / "meta.json").exists()
@@ -55,6 +62,13 @@ def export_cmd(step_file, formats, no_daemon):
 
     # Parse and validate formats
     fmt_list = parse_export_formats(formats)
+    if not fmt_list:
+        click.echo(json.dumps({
+            "command": "export",
+            "status": "error",
+            "message": NO_FORMATS_MESSAGE,
+        }))
+        sys.exit(1)
     invalid = unsupported_export_formats(formats)
     if invalid:
         click.echo(json.dumps({

--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -15,7 +15,11 @@ from agentcad.commands._daemon_routing import (
     maybe_route_through_daemon,
     maybe_spawn_daemon_for_next_run,
 )
-from agentcad.commands.export_cmd import parse_export_formats, unsupported_export_formats
+from agentcad.commands.export_cmd import (
+    NO_FORMATS_MESSAGE,
+    parse_export_formats,
+    unsupported_export_formats,
+)
 from agentcad.manifest import MANIFEST_FILE, load_manifest, save_manifest
 
 
@@ -478,6 +482,16 @@ def run(ctx, script, output, render, export, preview, open_view, params, dry_run
     # routing, version allocation, or any disk artifacts — so `run --export`
     # matches `agentcad export` instead of silently ignoring unknown formats.
     if export:
+        # An all-blank value (e.g. `--export ","`) parses to an empty list.
+        # Without this the run would execute the whole script and consume a
+        # version number, then export nothing and still report success.
+        if not parse_export_formats(export):
+            click.echo(json.dumps({
+                "command": "run",
+                "status": "error",
+                "message": NO_FORMATS_MESSAGE,
+            }))
+            sys.exit(1)
         invalid = unsupported_export_formats(export)
         if invalid:
             click.echo(json.dumps({

--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -481,7 +481,7 @@ def run(ctx, script, output, render, export, preview, open_view, params, dry_run
     # CAD-file suffix dispatch below (which drops --export entirely), daemon
     # routing, version allocation, or any disk artifacts — so `run --export`
     # matches `agentcad export` instead of silently ignoring unknown formats.
-    if export:
+    if export is not None:
         # An all-blank value (e.g. `--export ","`) parses to an empty list.
         # Without this the run would execute the whole script and consume a
         # version number, then export nothing and still report success.

--- a/tests/test_export_cmd.py
+++ b/tests/test_export_cmd.py
@@ -116,6 +116,21 @@ def test_export_invalid_format_error(runner, isolated_dir):
     assert parsed["status"] == "error"
 
 
+def test_export_empty_format_list_error(runner, isolated_dir):
+    """`--format ","` trims down to no formats at all. It must error rather than
+    report success with an empty outputs map."""
+    # File contents are never read: format validation precedes the CAD import.
+    step_path = isolated_dir / "model.step"
+    step_path.write_text("")
+    result = runner.invoke(cli, ["export", str(step_path), "--format", ","])
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "export"
+    assert parsed["status"] == "error"
+    assert "No export formats specified" in parsed["message"]
+    assert "Supported: stl, glb, obj" in parsed["message"]
+
+
 def test_export_obj_produces_file(runner, isolated_dir):
     step_path = _create_step(runner, isolated_dir)
     result = runner.invoke(cli, ["export", str(step_path), "--format", "obj"])

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -624,6 +624,24 @@ def test_run_rejects_empty_export_format_list_without_consuming_version(runner, 
     assert not any(isolated_dir.glob("v1_*"))
 
 
+def test_run_rejects_empty_string_export_format_list_without_consuming_version(runner, isolated_dir):
+    """`--export ""` is still an explicitly provided empty format list and
+    should fail the same way as an all-blank comma list."""
+    _init_project(runner)
+    _write_script(isolated_dir)
+    result = runner.invoke(cli, ["run", "script.py", "--output", "label", "--export", ""])
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "run"
+    assert parsed["status"] == "error"
+    assert "No export formats specified" in parsed["message"]
+    assert "Supported: stl, glb, obj" in parsed["message"]
+
+    manifest = json.loads((isolated_dir / MANIFEST_FILE).read_text())
+    assert manifest["versions"] == []
+    assert not any(isolated_dir.glob("v1_*"))
+
+
 def test_run_still_accepts_a_trailing_comma(runner, isolated_dir):
     """The other side of the fix: a trailing comma must still trim cleanly
     instead of being caught by the new empty-list check."""

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -606,6 +606,34 @@ def test_run_rejects_unsupported_export_format_without_consuming_version(runner,
     assert not any(isolated_dir.glob("v1_*"))
 
 
+def test_run_rejects_empty_export_format_list_without_consuming_version(runner, isolated_dir):
+    """`--export ","` parses to no formats at all. It must error rather than run
+    the script, consume a version, then export nothing and report success."""
+    _init_project(runner)
+    _write_script(isolated_dir)
+    result = runner.invoke(cli, ["run", "script.py", "--output", "label", "--export", ","])
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert parsed["command"] == "run"
+    assert parsed["status"] == "error"
+    assert "No export formats specified" in parsed["message"]
+    assert "Supported: stl, glb, obj" in parsed["message"]
+
+    manifest = json.loads((isolated_dir / MANIFEST_FILE).read_text())
+    assert manifest["versions"] == []
+    assert not any(isolated_dir.glob("v1_*"))
+
+
+def test_run_still_accepts_a_trailing_comma(runner, isolated_dir):
+    """The other side of the fix: a trailing comma must still trim cleanly
+    instead of being caught by the new empty-list check."""
+    _init_project(runner)
+    _write_script(isolated_dir)
+    result = runner.invoke(cli, ["run", "script.py", "--output", "label", "--export", "stl,"])
+    assert result.exit_code == 0
+    assert (isolated_dir / "v1_label" / "output.stl").exists()
+
+
 def test_run_with_export_and_render(runner, isolated_dir):
     _init_project(runner)
     _write_script(isolated_dir)

--- a/tests_b3d/test_run_end_to_end.py
+++ b/tests_b3d/test_run_end_to_end.py
@@ -642,6 +642,24 @@ class TestExportFlag:
         assert manifest["versions"] == []
         assert not any(isolated_dir.glob("v1_*"))
 
+    def test_rejects_empty_string_export_format_list_without_consuming_version(
+        self, runner, isolated_dir
+    ):
+        _init(runner, isolated_dir)
+        _write(isolated_dir, "s.py", SIMPLE)
+        r = _run(runner, "s.py", "--output", "label", "--export", "",
+                 "--no-preview")
+        assert r.exit_code == 1
+        parsed = json.loads(r.stdout)
+        assert parsed["command"] == "run"
+        assert parsed["status"] == "error"
+        assert "No export formats specified" in parsed["message"]
+        assert "Supported: stl, glb, obj" in parsed["message"]
+
+        manifest = json.loads((isolated_dir / "agentcad.json").read_text())
+        assert manifest["versions"] == []
+        assert not any(isolated_dir.glob("v1_*"))
+
     def test_still_accepts_a_trailing_comma(self, runner, isolated_dir):
         _init(runner, isolated_dir)
         _write(isolated_dir, "s.py", SIMPLE)

--- a/tests_b3d/test_run_end_to_end.py
+++ b/tests_b3d/test_run_end_to_end.py
@@ -624,6 +624,33 @@ class TestExportFlag:
         assert manifest["versions"] == []
         assert not any(isolated_dir.glob("v1_*"))
 
+    def test_rejects_empty_export_format_list_without_consuming_version(
+        self, runner, isolated_dir
+    ):
+        _init(runner, isolated_dir)
+        _write(isolated_dir, "s.py", SIMPLE)
+        r = _run(runner, "s.py", "--output", "label", "--export", ",",
+                 "--no-preview")
+        assert r.exit_code == 1
+        parsed = json.loads(r.stdout)
+        assert parsed["command"] == "run"
+        assert parsed["status"] == "error"
+        assert "No export formats specified" in parsed["message"]
+        assert "Supported: stl, glb, obj" in parsed["message"]
+
+        manifest = json.loads((isolated_dir / "agentcad.json").read_text())
+        assert manifest["versions"] == []
+        assert not any(isolated_dir.glob("v1_*"))
+
+    def test_still_accepts_a_trailing_comma(self, runner, isolated_dir):
+        _init(runner, isolated_dir)
+        _write(isolated_dir, "s.py", SIMPLE)
+        r = _run(runner, "s.py", "--output", "label", "--export", "stl,",
+                 "--no-preview")
+        assert r.exit_code == 0
+        parsed = json.loads(r.stdout)
+        assert "stl" in parsed["outputs"]
+
     # ---- parity ports from tests/test_run.py ----
 
     def test_export_and_render(self, runner, isolated_dir):


### PR DESCRIPTION
`parse_export_formats` drops blank entries — good for `stl,` — but when *every* entry is blank the parsed list is empty and both commands carried on.

## The fix
Both commands now return the standard structured error when the flag was provided but parsed to nothing:

```json
{"command": "export", "status": "error", "message": "No export formats specified. Supported: stl, glb, obj"}
```

The message lives in a shared `NO_FORMATS_MESSAGE` next to the other helpers in `export_cmd.py`, so `export` and `run --export` can't drift apart the way the issue describes.

In `run` the check sits at the **existing early validation seam** (same `if export:` block as the unsupported-format check), so it fires before the CAD-file suffix dispatch, daemon routing, version allocation, and any disk artifacts — which is the part that made this worse than a plain no-op.

## Verified against the issue's repro
```
$ agentcad export output.step --format ","
exit: 1
{"command": "export", "status": "error", "message": "No export formats specified. Supported: stl, glb, obj"}
```
Previously: `{"status": "success", "outputs": {}}`, exit 0.

## Tests
- `tests/test_export_cmd.py::test_export_empty_format_list_error`
- `tests/test_run.py::test_run_rejects_empty_export_format_list_without_consuming_version` — also asserts the manifest has no versions and no `v1_*` directory was created, mirroring the unsupported-format test.
- `tests/test_run.py::test_run_still_accepts_a_trailing_comma` — **guards the other side**, so this fix can't regress the `stl,` trimming that `parse_export_formats` deliberately supports.
- b3d twins for both `run` tests in `tests_b3d/test_run_end_to_end.py`, so the parity guardrail is satisfied by **name-matching rather than a PARITY_MAP exemption** (guardrail passes: 3 passed).

I revert-verified the new tests rather than trusting a green run: with the source fix stashed and the tests kept, both fail; with it restored, both pass.

## Local run
The validation happens before the CAD import, so the new cases are kernel-free and run here: 96 passed across `test_docs / test_help / test_help_consistency / test_init / test_context / test_parity_guardrail` plus the new tests. The kernel-backed cases (the trailing-comma exports, and the b3d twins) need cadquery/build123d and will run on your side.

Closes #100