### PR TITLE
Allow diffing standalone CAD files

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ to keep the phone from sliding. Show me a preview when you're done.
 - **`agentcad parts list REF`** — list named/captured parts for a version
 - **`agentcad parts show REF ID`** — show one versioned part by stable id
 - **`agentcad parts view REF`** — hand off an isolated, focused, or grouped part review viewer
-- **`agentcad diff 1 2`** — compare versions (metrics, outputs, parameters)
-- **`agentcad view old.step new.step`** — open an explicit synchronized A/B comparison
+- **`agentcad diff 1 2`** — compare versions, including actual shared/reference-only/candidate-only source-frame volume for valid closed solids
+- **`agentcad view old.step new.step`** — open a synchronized A/B comparison with separate centered projection and source-frame 3D volume artifacts
 - **`agentcad docs [section]`** — runtime-aware built-in documentation and worked examples
 
 ## No boilerplate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-mcp = ["mcp>=1.0.0"]
+mcp = ["mcp>=1.27,<2"]
 dev = ["pytest>=8.0", "pytest-timeout>=2.0", "playwright>=1.40"]
 
 [project.urls]

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -71,7 +71,7 @@ VERSION OUTPUTS
       meta.json         full run metadata, including runtime and parts
       preview.png       4-view composite: front, right, top, iso
       diff_side.png     side-by-side vs. prior success (from v2 onward)
-      diff_overlay.png  tinted overlay vs. prior success (from v2 onward)
+      diff_overlay.png  semantic added/removed map vs. prior (from v2 onward)
       viewer.html       interactive review viewer (opens automatically;
                         from v2: A=previous, B=current)
       renders/          requested PNG views

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -72,7 +72,10 @@ VERSION OUTPUTS
       meta.json         full run metadata, including runtime and parts
       preview.png       4-view composite: front, right, top, iso
       diff_side.png     side-by-side vs. prior success (from v2 onward)
-      diff_overlay.png  semantic added/removed map vs. prior (from v2 onward)
+      diff_overlay.png  centered 2D projection map vs. prior (from v2 onward)
+      diff_volume.png   source-frame shared/reference-only/candidate-only
+                        3D volume vs. prior (from v2 onward, valid solids)
+      diff_volume.glb   interactive colored geometry backing the 3D volume map
       viewer.html       interactive review viewer (opens automatically;
                         from v2: A=previous, B=current)
       renders/          requested PNG views
@@ -122,14 +125,17 @@ COMMAND REFERENCE: RENDER, EXPORT, AND REVIEW
   agentcad view FILE [FILE_B] [--overlay] [--measure] [--spec spec.json]
     Open an explicit browser review for STEP/STP or GLB; STEP auto-converts.
     A second file opens synchronized A/B comparison, or a red/green overlay
-    with --overlay. --measure embeds geometry measurements; --spec runs the
-    checklist and opens Spec check mode. Measurement and spec review require
-    STEP/STP source geometry.
+    with --overlay. Two STEP files also produce centered 2D projection and
+    source-frame 3D volume artifacts. --measure embeds geometry measurements;
+    --spec runs the checklist and opens Spec check mode. Measurement and spec
+    review require STEP/STP source geometry.
 
   agentcad diff REF1 REF2 [--visual] [--overlay]
     Compare version metrics, outputs, parameters, and parts. Refs may be version
-    numbers or labels. --visual opens the browser comparison; --overlay selects
-    its tinted overlay mode.
+    numbers, labels, or STEP/BREP paths. Closed solids also return actual shared,
+    reference-only, and candidate-only source-frame volumes; no alignment is
+    applied. --visual opens the browser comparison and writes colored volume
+    artifacts; --overlay selects its tinted interactive mode.
 
   agentcad parts list REF
   agentcad parts show REF PART_ID

--- a/src/agentcad/commands/diff.py
+++ b/src/agentcad/commands/diff.py
@@ -70,9 +70,9 @@ def _resolve_file_ref(ref):
     return p if p.is_file() else None
 
 
-def _load_file_metrics(path):
+def _load_file_shape_and_metrics(path):
     shape = load_cad_shape(path)
-    return compute_metrics(shape)
+    return shape, compute_metrics(shape)
 
 
 def _metric_changes(metrics_a, metrics_b):
@@ -120,8 +120,8 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
             sys.exit(1)
 
         try:
-            metrics_a = _load_file_metrics(file_a)
-            metrics_b = _load_file_metrics(file_b)
+            shape_a, metrics_a = _load_file_shape_and_metrics(file_a)
+            shape_b, metrics_b = _load_file_shape_and_metrics(file_b)
         except ValueError as exc:
             click.echo(json.dumps({
                 "command": "diff",
@@ -130,6 +130,9 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
             }))
             sys.exit(1)
 
+        from agentcad.solid_compare import compare_solid_volumes
+
+        solid_comparison = compare_solid_volumes(shape_a, shape_b)
         response = {
             "command": "diff",
             "status": "success",
@@ -138,10 +141,17 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
             "changes": {
                 "metrics": _metric_changes(metrics_a, metrics_b),
             },
+            "comparison_3d": solid_comparison.data,
         }
 
         if visual:
-            _add_visual_response(response, file_a, file_b, overlay)
+            _add_visual_response(
+                response,
+                file_a,
+                file_b,
+                overlay,
+                solid_comparison=solid_comparison,
+            )
 
         click.echo(json.dumps(response))
         maybe_spawn_daemon_for_next_run(no_daemon=no_daemon)
@@ -258,9 +268,21 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
         "changes": changes,
     }
 
+    step_a = _find_step_path(v1_entry, meta1)
+    step_b = _find_step_path(v2_entry, meta2)
+    solid_comparison = None
+    if step_a is not None and step_b is not None:
+        try:
+            from agentcad.solid_compare import compare_solid_volumes
+
+            shape_a = load_cad_shape(step_a)
+            shape_b = load_cad_shape(step_b)
+            solid_comparison = compare_solid_volumes(shape_a, shape_b)
+            response["comparison_3d"] = solid_comparison.data
+        except ValueError:
+            solid_comparison = None
+
     if visual:
-        step_a = _find_step_path(v1_entry, meta1)
-        step_b = _find_step_path(v2_entry, meta2)
         if step_a is None or step_b is None:
             click.echo(json.dumps({
                 "command": "diff",
@@ -268,7 +290,13 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
                 "message": "Could not find STEP outputs for one or both versions.",
             }))
             sys.exit(1)
-        _add_visual_response(response, step_a, step_b, overlay)
+        _add_visual_response(
+            response,
+            step_a,
+            step_b,
+            overlay,
+            solid_comparison=solid_comparison,
+        )
 
     click.echo(json.dumps(response))
 
@@ -279,12 +307,20 @@ def _relative_to_cwd(path):
     return str(path.relative_to(Path.cwd())) if path.is_relative_to(Path.cwd()) else str(path)
 
 
-def _add_visual_response(response, step_a, step_b, overlay):
+def _add_visual_response(
+    response,
+    step_a,
+    step_b,
+    overlay,
+    *,
+    solid_comparison=None,
+):
     from agentcad.commands.view import (
         _open_browser,
         _render_diff,
         _render_diff_overlay_png,
         _render_diff_png,
+        _render_solid_comparison_artifacts,
         _resolve_to_glb_and_shape,
     )
 
@@ -299,11 +335,24 @@ def _add_visual_response(response, step_a, step_b, overlay):
 
     png_path = None
     overlay_png_path = None
-    comparison = None
+    volume_glb_path = None
+    volume_png_path = None
+    projection_comparison = None
     if shape_a is not None and shape_b is not None:
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, Path.cwd())
-        overlay_png_path, comparison = _render_diff_overlay_png(
+        overlay_png_path, projection_comparison = _render_diff_overlay_png(
             shape_a, shape_b, glb_a, glb_b, Path.cwd()
+        )
+        if solid_comparison is None:
+            from agentcad.solid_compare import compare_solid_volumes
+
+            solid_comparison = compare_solid_volumes(shape_a, shape_b)
+            response["comparison_3d"] = solid_comparison.data
+        volume_glb_path, volume_png_path = _render_solid_comparison_artifacts(
+            solid_comparison,
+            glb_a,
+            glb_b,
+            Path.cwd(),
         )
 
     html_path, url, mode = _render_diff(
@@ -313,6 +362,7 @@ def _add_visual_response(response, step_a, step_b, overlay):
         out_dir=Path.cwd(),
         diff_side_png=png_path,
         diff_overlay_png=overlay_png_path,
+        diff_volume_png=volume_png_path,
     )
 
     visual_resp = {
@@ -325,8 +375,12 @@ def _add_visual_response(response, step_a, step_b, overlay):
         visual_resp["png"] = _relative_to_cwd(png_path)
     if overlay_png_path is not None:
         visual_resp["overlay_png"] = _relative_to_cwd(overlay_png_path)
-    if comparison is not None:
-        visual_resp["comparison"] = comparison
+    if projection_comparison is not None:
+        visual_resp["projection_comparison"] = projection_comparison
+    if volume_glb_path is not None:
+        visual_resp["volume_glb"] = _relative_to_cwd(volume_glb_path)
+    if volume_png_path is not None:
+        visual_resp["volume_png"] = _relative_to_cwd(volume_png_path)
 
     _open_browser(url)
     response["visual"] = visual_resp

--- a/src/agentcad/commands/diff.py
+++ b/src/agentcad/commands/diff.py
@@ -299,9 +299,10 @@ def _add_visual_response(response, step_a, step_b, overlay):
 
     png_path = None
     overlay_png_path = None
+    comparison = None
     if shape_a is not None and shape_b is not None:
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, Path.cwd())
-        overlay_png_path = _render_diff_overlay_png(
+        overlay_png_path, comparison = _render_diff_overlay_png(
             shape_a, shape_b, glb_a, glb_b, Path.cwd()
         )
 
@@ -324,6 +325,8 @@ def _add_visual_response(response, step_a, step_b, overlay):
         visual_resp["png"] = _relative_to_cwd(png_path)
     if overlay_png_path is not None:
         visual_resp["overlay_png"] = _relative_to_cwd(overlay_png_path)
+    if comparison is not None:
+        visual_resp["comparison"] = comparison
 
     _open_browser(url)
     response["visual"] = visual_resp

--- a/src/agentcad/commands/diff.py
+++ b/src/agentcad/commands/diff.py
@@ -9,6 +9,10 @@ from agentcad.commands._daemon_routing import (
     maybe_spawn_daemon_for_next_run,
 )
 from agentcad.manifest import load_manifest
+from agentcad.metrics import compute_metrics
+from agentcad.step_io import load_cad_shape
+
+_CAD_FILE_SUFFIXES = {".step", ".stp", ".brep"}
 
 
 def _resolve_version(manifest, ref):
@@ -56,6 +60,26 @@ def _scalar_diff(old_val, new_val):
     return {"from": old_val, "to": new_val}
 
 
+def _looks_like_file_ref(ref):
+    p = Path(ref).expanduser()
+    return p.suffix.lower() in _CAD_FILE_SUFFIXES or "/" in ref or "\\" in ref
+
+
+def _resolve_file_ref(ref):
+    p = Path(ref).expanduser()
+    return p if p.is_file() else None
+
+
+def _load_file_metrics(path):
+    shape = load_cad_shape(path)
+    return compute_metrics(shape)
+
+
+def _metric_changes(metrics_a, metrics_b):
+    all_keys = sorted(set(metrics_a.keys()) | set(metrics_b.keys()))
+    return {k: _scalar_diff(metrics_a.get(k), metrics_b.get(k)) for k in all_keys}
+
+
 @click.command()
 @click.argument("ref1")
 @click.argument("ref2")
@@ -71,6 +95,57 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
     if overlay:
         argv.append("--overlay")
     maybe_route_through_daemon(argv, no_daemon=no_daemon)
+
+    file_a = _resolve_file_ref(ref1)
+    file_b = _resolve_file_ref(ref2)
+    if (
+        file_a is not None
+        or file_b is not None
+        or _looks_like_file_ref(ref1)
+        or _looks_like_file_ref(ref2)
+    ):
+        if file_a is None:
+            click.echo(json.dumps({
+                "command": "diff",
+                "status": "error",
+                "message": f"File '{ref1}' not found.",
+            }))
+            sys.exit(1)
+        if file_b is None:
+            click.echo(json.dumps({
+                "command": "diff",
+                "status": "error",
+                "message": f"File '{ref2}' not found.",
+            }))
+            sys.exit(1)
+
+        try:
+            metrics_a = _load_file_metrics(file_a)
+            metrics_b = _load_file_metrics(file_b)
+        except ValueError as exc:
+            click.echo(json.dumps({
+                "command": "diff",
+                "status": "error",
+                "message": str(exc),
+            }))
+            sys.exit(1)
+
+        response = {
+            "command": "diff",
+            "status": "success",
+            "v1": {"file": _relative_to_cwd(file_a), "label": file_a.name},
+            "v2": {"file": _relative_to_cwd(file_b), "label": file_b.name},
+            "changes": {
+                "metrics": _metric_changes(metrics_a, metrics_b),
+            },
+        }
+
+        if visual:
+            _add_visual_response(response, file_a, file_b, overlay)
+
+        click.echo(json.dumps(response))
+        maybe_spawn_daemon_for_next_run(no_daemon=no_daemon)
+        return
 
     manifest = load_manifest(command="diff")
 
@@ -193,33 +268,7 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
                 "message": "Could not find STEP outputs for one or both versions.",
             }))
             sys.exit(1)
-
-        from agentcad.commands.view import _resolve_to_glb_and_shape, _render_diff, _render_diff_png, _open_browser
-
-        glb_a, shape_a, err = _resolve_to_glb_and_shape(str(step_a))
-        if err:
-            click.echo(json.dumps({"command": "diff", "status": "error", "message": err}))
-            sys.exit(1)
-        glb_b, shape_b, err = _resolve_to_glb_and_shape(str(step_b))
-        if err:
-            click.echo(json.dumps({"command": "diff", "status": "error", "message": err}))
-            sys.exit(1)
-
-        html_path, url, mode = _render_diff(glb_a, glb_b, overlay=overlay, out_dir=Path.cwd())
-
-        visual_resp = {
-            "mode": mode,
-            "html": _relative_to_cwd(html_path),
-            "url": url,
-        }
-
-        # Agent-facing: side-by-side PNG (skipped for overlay mode for now)
-        if shape_a is not None and shape_b is not None and not overlay:
-            png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, Path.cwd())
-            visual_resp["png"] = _relative_to_cwd(png_path)
-
-        _open_browser(url)
-        response["visual"] = visual_resp
+        _add_visual_response(response, step_a, step_b, overlay)
 
     click.echo(json.dumps(response))
 
@@ -228,6 +277,48 @@ def diff(ref1, ref2, visual, overlay, no_daemon):
 
 def _relative_to_cwd(path):
     return str(path.relative_to(Path.cwd())) if path.is_relative_to(Path.cwd()) else str(path)
+
+
+def _add_visual_response(response, step_a, step_b, overlay):
+    from agentcad.commands.view import (
+        _open_browser,
+        _render_diff,
+        _render_diff_png,
+        _resolve_to_glb_and_shape,
+    )
+
+    glb_a, shape_a, err = _resolve_to_glb_and_shape(str(step_a))
+    if err:
+        click.echo(json.dumps({"command": "diff", "status": "error", "message": err}))
+        sys.exit(1)
+    glb_b, shape_b, err = _resolve_to_glb_and_shape(str(step_b))
+    if err:
+        click.echo(json.dumps({"command": "diff", "status": "error", "message": err}))
+        sys.exit(1)
+
+    png_path = None
+    if shape_a is not None and shape_b is not None and not overlay:
+        png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, Path.cwd())
+
+    html_path, url, mode = _render_diff(
+        glb_a,
+        glb_b,
+        overlay=overlay,
+        out_dir=Path.cwd(),
+        diff_side_png=png_path,
+    )
+
+    visual_resp = {
+        "mode": mode,
+        "html": _relative_to_cwd(html_path),
+        "url": url,
+    }
+
+    if png_path is not None:
+        visual_resp["png"] = _relative_to_cwd(png_path)
+
+    _open_browser(url)
+    response["visual"] = visual_resp
 
 
 def _find_step_path(version_entry, meta):

--- a/src/agentcad/commands/diff.py
+++ b/src/agentcad/commands/diff.py
@@ -283,6 +283,7 @@ def _add_visual_response(response, step_a, step_b, overlay):
     from agentcad.commands.view import (
         _open_browser,
         _render_diff,
+        _render_diff_overlay_png,
         _render_diff_png,
         _resolve_to_glb_and_shape,
     )
@@ -297,8 +298,12 @@ def _add_visual_response(response, step_a, step_b, overlay):
         sys.exit(1)
 
     png_path = None
-    if shape_a is not None and shape_b is not None and not overlay:
+    overlay_png_path = None
+    if shape_a is not None and shape_b is not None:
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, Path.cwd())
+        overlay_png_path = _render_diff_overlay_png(
+            shape_a, shape_b, glb_a, glb_b, Path.cwd()
+        )
 
     html_path, url, mode = _render_diff(
         glb_a,
@@ -306,6 +311,7 @@ def _add_visual_response(response, step_a, step_b, overlay):
         overlay=overlay,
         out_dir=Path.cwd(),
         diff_side_png=png_path,
+        diff_overlay_png=overlay_png_path,
     )
 
     visual_resp = {
@@ -316,6 +322,8 @@ def _add_visual_response(response, step_a, step_b, overlay):
 
     if png_path is not None:
         visual_resp["png"] = _relative_to_cwd(png_path)
+    if overlay_png_path is not None:
+        visual_resp["overlay_png"] = _relative_to_cwd(overlay_png_path)
 
     _open_browser(url)
     response["visual"] = visual_resp

--- a/src/agentcad/commands/docs.py
+++ b/src/agentcad/commands/docs.py
@@ -154,10 +154,10 @@ SECTIONS = {
         "    check-spec\n"
         "             file, spec_file, passed, matched_features, missing_features,\n"
         "             total_abs_count_error, validity, metrics\n"
-        "    view     url, model | mode, url, model_a, model_b, png?\n"
+        "    view     url, model | mode, url, model_a, model_b, png?, comparison?\n"
         "    parts   version, label, viewer?, viewer_glb?, parts[] / part\n"
         "    diff     v1, v2, changes (with 'outputs', 'renders', 'metrics', 'parts'?\n"
-        "             subkeys), visual?\n"
+        "             subkeys), visual? (artifacts plus structured comparison)\n"
     ),
     "export": (
         "Exporting mesh formats:\n"

--- a/src/agentcad/commands/docs.py
+++ b/src/agentcad/commands/docs.py
@@ -154,10 +154,12 @@ SECTIONS = {
         "    check-spec\n"
         "             file, spec_file, passed, matched_features, missing_features,\n"
         "             total_abs_count_error, validity, metrics\n"
-        "    view     url, model | mode, url, model_a, model_b, png?, comparison?\n"
+        "    view     url, model | mode, url, model_a, model_b, png?,\n"
+        "             projection_comparison?, comparison_3d?, volume_png?, volume_glb?\n"
         "    parts   version, label, viewer?, viewer_glb?, parts[] / part\n"
         "    diff     v1, v2, changes (with 'outputs', 'renders', 'metrics', 'parts'?\n"
-        "             subkeys), visual? (artifacts plus structured comparison)\n"
+        "             subkeys), comparison_3d?, visual? (side-by-side, centered\n"
+        "             projection, and source-frame 3D volume artifacts)\n"
     ),
     "export": (
         "Exporting mesh formats:\n"

--- a/src/agentcad/commands/import_cmd.py
+++ b/src/agentcad/commands/import_cmd.py
@@ -185,12 +185,39 @@ def import_cmd(file, label, init_flag, open_view, no_daemon):
                     prev_shape, topo_shape, prev["label"], label,
                     overlay, width=1024, height=1024,
                 )
+                from agentcad.solid_compare import (
+                    compare_solid_volumes,
+                    write_solid_comparison_artifacts,
+                )
+
+                solid_comparison = compare_solid_volumes(
+                    prev_shape,
+                    topo_shape,
+                )
                 diff_meta = {
                     "against": prev["label"],
                     "side_by_side": f"{dir_name}/diff_side.png",
                     "overlay": f"{dir_name}/diff_overlay.png",
-                    "comparison": comparison,
+                    "projection_comparison": comparison,
+                    "comparison_3d": solid_comparison.data,
                 }
+                volume_glb = version_dir / "diff_volume.glb"
+                volume_png = version_dir / "diff_volume.png"
+                try:
+                    if write_solid_comparison_artifacts(
+                        solid_comparison,
+                        volume_glb,
+                        volume_png,
+                    ):
+                        diff_meta["volume_glb"] = (
+                            f"{dir_name}/diff_volume.glb"
+                        )
+                        diff_meta["volume_png"] = (
+                            f"{dir_name}/diff_volume.png"
+                        )
+                except Exception:
+                    # Numeric comparison remains useful if artifact export fails.
+                    pass
             except Exception:
                 # Diff is best-effort — never fail the whole import.
                 diff_meta = None
@@ -210,6 +237,11 @@ def import_cmd(file, label, init_flag, open_view, no_daemon):
         preview_png=preview_path,
         diff_side_png=(version_dir / "diff_side.png") if diff_meta else None,
         diff_overlay_png=(version_dir / "diff_overlay.png") if diff_meta else None,
+        diff_volume_png=(
+            version_dir / "diff_volume.png"
+            if diff_meta and diff_meta.get("volume_png")
+            else None
+        ),
     )
 
     viewer_opened = False

--- a/src/agentcad/commands/import_cmd.py
+++ b/src/agentcad/commands/import_cmd.py
@@ -181,7 +181,7 @@ def import_cmd(file, label, init_flag, open_view, no_daemon):
                     prev_shape, topo_shape, prev["label"], label,
                     side, width=512, height=512,
                 )
-                render_diff_overlay(
+                comparison = render_diff_overlay(
                     prev_shape, topo_shape, prev["label"], label,
                     overlay, width=1024, height=1024,
                 )
@@ -189,6 +189,7 @@ def import_cmd(file, label, init_flag, open_view, no_daemon):
                     "against": prev["label"],
                     "side_by_side": f"{dir_name}/diff_side.png",
                     "overlay": f"{dir_name}/diff_overlay.png",
+                    "comparison": comparison,
                 }
             except Exception:
                 # Diff is best-effort — never fail the whole import.

--- a/src/agentcad/commands/parts.py
+++ b/src/agentcad/commands/parts.py
@@ -433,6 +433,7 @@ def view_parts(
         preview_png=_existing_file(version_dir / "preview.png"),
         diff_side_png=_existing_file(version_dir / "diff_side.png"),
         diff_overlay_png=_existing_file(version_dir / "diff_overlay.png"),
+        diff_volume_png=_existing_file(version_dir / "diff_volume.png"),
         parts=parts,
         groups=groups,
         part_review=review_state,

--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -1011,7 +1011,7 @@ def _run_impl(ctx, script, output, render, export, preview, open_view, params,
                     width=512, height=512,
                     parts_b=glb_parts,
                 )
-                render_diff_overlay(
+                comparison = render_diff_overlay(
                     prev_shape, topo_shape_for_metrics,
                     prev["label"], label, overlay_path,
                     width=1024, height=1024,
@@ -1021,6 +1021,7 @@ def _run_impl(ctx, script, output, render, export, preview, open_view, params,
                     "against": prev["label"],
                     "side_by_side": f"{dir_name}/diff_side.png",
                     "overlay": f"{dir_name}/diff_overlay.png",
+                    "comparison": comparison,
                 }
             except Exception as e:
                 warnings.append(

--- a/src/agentcad/commands/run.py
+++ b/src/agentcad/commands/run.py
@@ -1017,12 +1017,41 @@ def _run_impl(ctx, script, output, render, export, preview, open_view, params,
                     width=1024, height=1024,
                     parts_b=glb_parts,
                 )
+                from agentcad.solid_compare import (
+                    compare_solid_volumes,
+                    write_solid_comparison_artifacts,
+                )
+
+                solid_comparison = compare_solid_volumes(
+                    prev_shape,
+                    topo_shape_for_metrics,
+                )
                 diff_meta = {
                     "against": prev["label"],
                     "side_by_side": f"{dir_name}/diff_side.png",
                     "overlay": f"{dir_name}/diff_overlay.png",
-                    "comparison": comparison,
+                    "projection_comparison": comparison,
+                    "comparison_3d": solid_comparison.data,
                 }
+                try:
+                    volume_glb_path = version_dir / "diff_volume.glb"
+                    volume_png_path = version_dir / "diff_volume.png"
+                    if write_solid_comparison_artifacts(
+                        solid_comparison,
+                        volume_glb_path,
+                        volume_png_path,
+                    ):
+                        diff_meta["volume_glb"] = (
+                            f"{dir_name}/diff_volume.glb"
+                        )
+                        diff_meta["volume_png"] = (
+                            f"{dir_name}/diff_volume.png"
+                        )
+                except Exception as exc:
+                    warnings.append(
+                        "Could not write 3D volume comparison artifacts: "
+                        f"{type(exc).__name__}: {exc}"
+                    )
             except Exception as e:
                 warnings.append(
                     f"Could not render diff against v{prev['version']}_{prev['label']}: {type(e).__name__}: {e}"
@@ -1062,6 +1091,11 @@ def _run_impl(ctx, script, output, render, export, preview, open_view, params,
         preview_png=version_dir / "preview.png" if preview_meta else None,
         diff_side_png=version_dir / "diff_side.png" if diff_meta else None,
         diff_overlay_png=version_dir / "diff_overlay.png" if diff_meta else None,
+        diff_volume_png=(
+            version_dir / "diff_volume.png"
+            if diff_meta and diff_meta.get("volume_png")
+            else None
+        ),
         parts=parts_output,
         parts_model="b" if prev_glb_path else "a",
         part_changes=part_changes,

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -26,6 +26,7 @@ import click
 #   __PREVIEW_PNG_URL__      base64 data URI for preview.png, or ""
 #   __DIFF_SIDE_PNG_URL__    base64 data URI for diff_side.png, or ""
 #   __DIFF_OVERLAY_PNG_URL__ base64 data URI for diff_overlay.png, or ""
+#   __DIFF_VOLUME_PNG_URL__  base64 data URI for diff_volume.png, or ""
 #   __DEFAULT_MODE__         starting mode string
 #   __PARTS_MODEL__          model ("a" or "b") represented by PARTS
 #   __PART_CHANGES_JSON__    previous/current named-part change summary, or null
@@ -313,8 +314,12 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     <img id="img-diff-side">
   </div>
   <div class="panel" id="panel-diff-overlay" style="display:none;">
-    <h3>diff_overlay.png — semantic difference map (shared gray, removed blue, added orange)</h3>
+    <h3>diff_overlay.png — centered 2D projection map (coincident gray, reference-only blue, candidate-only orange)</h3>
     <img id="img-diff-overlay">
+  </div>
+  <div class="panel" id="panel-diff-volume" style="display:none;">
+    <h3>diff_volume.png — source-frame 3D volume (shared gray, reference-only blue, candidate-only orange)</h3>
+    <img id="img-diff-volume">
   </div>
 </div>
 <div id="parts-view">
@@ -412,6 +417,7 @@ const LABEL_B = "__LABEL_B__";
 const PREVIEW_PNG_URL = "__PREVIEW_PNG_URL__";
 const DIFF_SIDE_PNG_URL = "__DIFF_SIDE_PNG_URL__";
 const DIFF_OVERLAY_PNG_URL = "__DIFF_OVERLAY_PNG_URL__";
+const DIFF_VOLUME_PNG_URL = "__DIFF_VOLUME_PNG_URL__";
 const DEFAULT_MODE = "__DEFAULT_MODE__";
 const PARTS_MODEL = "__PARTS_MODEL__";
 const PARTS = __PARTS_JSON__;
@@ -421,7 +427,7 @@ const REVIEW = __REVIEW_JSON__;
 const PART_REVIEW = __PART_REVIEW_JSON__;
 
 const hasB = MODEL_B_URL.length > 0;
-const hasAgentImgs = PREVIEW_PNG_URL.length > 0 || DIFF_SIDE_PNG_URL.length > 0 || DIFF_OVERLAY_PNG_URL.length > 0;
+const hasAgentImgs = PREVIEW_PNG_URL.length > 0 || DIFF_SIDE_PNG_URL.length > 0 || DIFF_OVERLAY_PNG_URL.length > 0 || DIFF_VOLUME_PNG_URL.length > 0;
 const hasAgentState = Boolean(PART_REVIEW);
 const hasAgentView = hasAgentImgs || hasAgentState;
 const hasParts = Array.isArray(PARTS) && PARTS.length > 0;
@@ -473,6 +479,7 @@ function setupModeButtons() {
   if (PREVIEW_PNG_URL) { document.getElementById('panel-preview').style.display = ''; document.getElementById('img-preview').src = PREVIEW_PNG_URL; }
   if (DIFF_SIDE_PNG_URL) { document.getElementById('panel-diff-side').style.display = ''; document.getElementById('img-diff-side').src = DIFF_SIDE_PNG_URL; }
   if (DIFF_OVERLAY_PNG_URL) { document.getElementById('panel-diff-overlay').style.display = ''; document.getElementById('img-diff-overlay').src = DIFF_OVERLAY_PNG_URL; }
+  if (DIFF_VOLUME_PNG_URL) { document.getElementById('panel-diff-volume').style.display = ''; document.getElementById('img-diff-volume').src = DIFF_VOLUME_PNG_URL; }
 
   if (hasPartsView) {
     setupStaticPartsPanel();
@@ -1959,6 +1966,7 @@ def _render_unified(
     preview_png=None,
     diff_side_png=None,
     diff_overlay_png=None,
+    diff_volume_png=None,
     parts=None,
     parts_model="a",
     part_changes=None,
@@ -1987,6 +1995,7 @@ def _render_unified(
         "__PREVIEW_PNG_URL__": _embed_data_uri(preview_png),
         "__DIFF_SIDE_PNG_URL__": _embed_data_uri(diff_side_png),
         "__DIFF_OVERLAY_PNG_URL__": _embed_data_uri(diff_overlay_png),
+        "__DIFF_VOLUME_PNG_URL__": _embed_data_uri(diff_volume_png),
         "__DEFAULT_MODE__": default_mode,
         "__PARTS_MODEL__": parts_model,
         "__PARTS_JSON__": json.dumps(parts_payload),
@@ -2022,6 +2031,7 @@ def _render_diff(
     review=None,
     diff_side_png=None,
     diff_overlay_png=None,
+    diff_volume_png=None,
 ):
     """Write diff viewer HTML (with side-by-side or overlay as default).
 
@@ -2040,6 +2050,7 @@ def _render_diff(
         default_mode=mode,
         diff_side_png=diff_side_png,
         diff_overlay_png=diff_overlay_png,
+        diff_volume_png=diff_volume_png,
         review=review,
     )
     return html_path, html_path.as_uri(), mode
@@ -2069,6 +2080,33 @@ def _render_diff_overlay_png(shape_a, shape_b, glb_a, glb_b, out_dir):
         shape_a, shape_b, glb_a.name, glb_b.name, png_path
     )
     return png_path, comparison
+
+
+def _render_solid_comparison_artifacts(
+    solid_comparison,
+    glb_a,
+    glb_b,
+    out_dir,
+):
+    """Write colored source-frame Boolean comparison artifacts."""
+    from agentcad.solid_compare import write_solid_comparison_artifacts
+
+    label_a, label_b = _diff_name_parts(glb_a, glb_b)
+    base = out_dir / f"diff_{label_a}_{label_b}_volume"
+    glb_path = base.with_suffix(".glb")
+    png_path = base.with_suffix(".png")
+    try:
+        written = write_solid_comparison_artifacts(
+            solid_comparison,
+            glb_path,
+            png_path,
+        )
+    except Exception:
+        # Numeric comparison remains authoritative if rendering/export fails.
+        return None, None
+    if not written:
+        return None, None
+    return glb_path, png_path
 
 
 def _review_error(message):
@@ -2210,11 +2248,23 @@ def view(file, file_b, overlay, with_measure, spec_file):
     out_dir = glb_a.parent
     png_path = None
     overlay_png_path = None
-    comparison = None
+    volume_glb_path = None
+    volume_png_path = None
+    projection_comparison = None
+    solid_comparison = None
     if shape_a is not None and shape_b is not None:
+        from agentcad.solid_compare import compare_solid_volumes
+
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir)
-        overlay_png_path, comparison = _render_diff_overlay_png(
+        overlay_png_path, projection_comparison = _render_diff_overlay_png(
             shape_a, shape_b, glb_a, glb_b, out_dir
+        )
+        solid_comparison = compare_solid_volumes(shape_a, shape_b)
+        volume_glb_path, volume_png_path = _render_solid_comparison_artifacts(
+            solid_comparison,
+            glb_a,
+            glb_b,
+            out_dir,
         )
 
     html_path, url, mode = _render_diff(
@@ -2224,6 +2274,7 @@ def view(file, file_b, overlay, with_measure, spec_file):
         review=review,
         diff_side_png=png_path,
         diff_overlay_png=overlay_png_path,
+        diff_volume_png=volume_png_path,
     )
 
     response = {
@@ -2241,8 +2292,14 @@ def view(file, file_b, overlay, with_measure, spec_file):
         response["png"] = str(png_path)
     if overlay_png_path is not None:
         response["overlay_png"] = str(overlay_png_path)
-    if comparison is not None:
-        response["comparison"] = comparison
+    if projection_comparison is not None:
+        response["projection_comparison"] = projection_comparison
+    if solid_comparison is not None:
+        response["comparison_3d"] = solid_comparison.data
+    if volume_glb_path is not None:
+        response["volume_glb"] = str(volume_glb_path)
+    if volume_png_path is not None:
+        response["volume_png"] = str(volume_png_path)
 
     _open_browser(url)
     click.echo(json.dumps(response))

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -309,11 +309,11 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     <img id="img-preview">
   </div>
   <div class="panel" id="panel-diff-side" style="display:none;">
-    <h3>diff_side.png — side-by-side (A: previous, B: this run) the agent reads for "what changed"</h3>
+    <h3>diff_side.png — four matched views of A (previous) and B (this run)</h3>
     <img id="img-diff-side">
   </div>
   <div class="panel" id="panel-diff-overlay" style="display:none;">
-    <h3>diff_overlay.png — tinted overlay (green A, red B) for spotting subtle shifts</h3>
+    <h3>diff_overlay.png — four center-aligned overlays (green A, red B)</h3>
     <img id="img-diff-overlay">
   </div>
 </div>
@@ -1235,7 +1235,9 @@ function orientMarker(marker, axis) {
 }
 
 function cadPointToViewer(point) {
-  return new THREE.Vector3(Number(point.x), Number(point.z), -Number(point.y));
+  const viewerPoint = new THREE.Vector3(Number(point.x), Number(point.z), -Number(point.y));
+  if (reviewModelA) viewerPoint.add(reviewModelA.position);
+  return viewerPoint;
 }
 
 function reviewMetrics() {
@@ -1247,10 +1249,18 @@ function viewerBoundingBox() {
   const x = bbox.x || null;
   const y = bbox.y || null;
   const z = bbox.z || null;
+  const offset = reviewModelA ? reviewModelA.position : new THREE.Vector3();
+  const shifted = (range, amount) => (
+    Array.isArray(range) && range.length === 2
+      ? [Number(range[0]) + amount, Number(range[1]) + amount]
+      : null
+  );
   return {
-    x,
-    y: z,
-    z: Array.isArray(y) && y.length === 2 ? [-Number(y[1]), -Number(y[0])] : null,
+    x: shifted(x, offset.x),
+    y: shifted(z, offset.y),
+    z: Array.isArray(y) && y.length === 2
+      ? [-Number(y[1]) + offset.z, -Number(y[0]) + offset.z]
+      : null,
   };
 }
 
@@ -1504,13 +1514,19 @@ const combinedBox = new THREE.Box3();
 
 const loader = new GLTFLoader();
 
-function attach(scene, url, { material, onMesh }) {
+function attach(scene, url, { material, onMesh, alignToCenter=false }) {
   return new Promise(resolve => {
     if (!url) { resolve(null); return; }
     loader.load(url, gltf => {
       const model = gltf.scene;
       if (material) {
         model.traverse(c => { if (c.isMesh) c.material = material; });
+      }
+      if (alignToCenter) {
+        const sourceBox = new THREE.Box3().setFromObject(model);
+        const sourceCenter = sourceBox.getCenter(new THREE.Vector3());
+        model.position.sub(sourceCenter);
+        model.updateMatrixWorld(true);
       }
       scene.add(model);
 
@@ -1550,6 +1566,7 @@ function fitCamera() {
 // Load all scenes in parallel, then fit camera
 Promise.all([
   attach(sceneA_single, MODEL_A_URL, {
+    alignToCenter: hasB,
     onMesh: m => {
       reviewModelA = m;
       if (PARTS_MODEL === 'a') {
@@ -1559,12 +1576,21 @@ Promise.all([
     },
   }),
   hasB ? attach(sceneB_single, MODEL_B_URL, {
+    alignToCenter: true,
     onMesh: PARTS_MODEL === 'b' ? m => { registerPartMeshes(m); applyPartState(); } : null,
   }) : null,
-  hasB ? attach(sceneA_split, MODEL_A_URL, {}) : null,
-  hasB ? attach(sceneB_split, MODEL_B_URL, {}) : null,
-  hasB ? attach(sceneOverlay, MODEL_A_URL, { material: tintA, onMesh: m => overlayModelA = m }) : null,
-  hasB ? attach(sceneOverlay, MODEL_B_URL, { material: tintB, onMesh: m => overlayModelB = m }) : null,
+  hasB ? attach(sceneA_split, MODEL_A_URL, { alignToCenter: true }) : null,
+  hasB ? attach(sceneB_split, MODEL_B_URL, { alignToCenter: true }) : null,
+  hasB ? attach(sceneOverlay, MODEL_A_URL, {
+    material: tintA,
+    alignToCenter: true,
+    onMesh: m => overlayModelA = m,
+  }) : null,
+  hasB ? attach(sceneOverlay, MODEL_B_URL, {
+    material: tintB,
+    alignToCenter: true,
+    onMesh: m => overlayModelB = m,
+  }) : null,
 ].filter(Boolean)).then(() => {
   fitCamera();
   applyPartState();
@@ -2025,11 +2051,21 @@ def _diff_png_path(glb_a, glb_b, out_dir):
 
 
 def _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir):
-    """Render the side-by-side comparison PNG next to the diff HTML."""
+    """Render the four-view side-by-side comparison next to the diff HTML."""
     from agentcad.render import render_diff_side_by_side
 
     png_path = _diff_png_path(glb_a, glb_b, out_dir)
     render_diff_side_by_side(shape_a, shape_b, glb_a.name, glb_b.name, png_path)
+    return png_path
+
+
+def _render_diff_overlay_png(shape_a, shape_b, glb_a, glb_b, out_dir):
+    """Render the four-view center-aligned overlay next to the diff HTML."""
+    from agentcad.render import render_diff_overlay
+
+    label_a, label_b = _diff_name_parts(glb_a, glb_b)
+    png_path = out_dir / f"diff_{label_a}_{label_b}_overlay.png"
+    render_diff_overlay(shape_a, shape_b, glb_a.name, glb_b.name, png_path)
     return png_path
 
 
@@ -2171,8 +2207,12 @@ def view(file, file_b, overlay, with_measure, spec_file):
 
     out_dir = glb_a.parent
     png_path = None
-    if shape_a is not None and shape_b is not None and not overlay:
+    overlay_png_path = None
+    if shape_a is not None and shape_b is not None:
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir)
+        overlay_png_path = _render_diff_overlay_png(
+            shape_a, shape_b, glb_a, glb_b, out_dir
+        )
 
     html_path, url, mode = _render_diff(
         glb_a,
@@ -2180,6 +2220,7 @@ def view(file, file_b, overlay, with_measure, spec_file):
         overlay=overlay,
         review=review,
         diff_side_png=png_path,
+        diff_overlay_png=overlay_png_path,
     )
 
     response = {
@@ -2195,6 +2236,8 @@ def view(file, file_b, overlay, with_measure, spec_file):
 
     if png_path is not None:
         response["png"] = str(png_path)
+    if overlay_png_path is not None:
+        response["overlay_png"] = str(overlay_png_path)
 
     _open_browser(url)
     click.echo(json.dumps(response))

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -313,7 +313,7 @@ _HTML_UNIFIED = r"""<!DOCTYPE html>
     <img id="img-diff-side">
   </div>
   <div class="panel" id="panel-diff-overlay" style="display:none;">
-    <h3>diff_overlay.png — four center-aligned overlays (green A, red B)</h3>
+    <h3>diff_overlay.png — semantic difference map (shared gray, removed blue, added orange)</h3>
     <img id="img-diff-overlay">
   </div>
 </div>
@@ -2060,13 +2060,15 @@ def _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir):
 
 
 def _render_diff_overlay_png(shape_a, shape_b, glb_a, glb_b, out_dir):
-    """Render the four-view center-aligned overlay next to the diff HTML."""
+    """Render the four-view semantic difference map next to the diff HTML."""
     from agentcad.render import render_diff_overlay
 
     label_a, label_b = _diff_name_parts(glb_a, glb_b)
     png_path = out_dir / f"diff_{label_a}_{label_b}_overlay.png"
-    render_diff_overlay(shape_a, shape_b, glb_a.name, glb_b.name, png_path)
-    return png_path
+    comparison = render_diff_overlay(
+        shape_a, shape_b, glb_a.name, glb_b.name, png_path
+    )
+    return png_path, comparison
 
 
 def _review_error(message):
@@ -2208,9 +2210,10 @@ def view(file, file_b, overlay, with_measure, spec_file):
     out_dir = glb_a.parent
     png_path = None
     overlay_png_path = None
+    comparison = None
     if shape_a is not None and shape_b is not None:
         png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir)
-        overlay_png_path = _render_diff_overlay_png(
+        overlay_png_path, comparison = _render_diff_overlay_png(
             shape_a, shape_b, glb_a, glb_b, out_dir
         )
 
@@ -2238,6 +2241,8 @@ def view(file, file_b, overlay, with_measure, spec_file):
         response["png"] = str(png_path)
     if overlay_png_path is not None:
         response["overlay_png"] = str(overlay_png_path)
+    if comparison is not None:
+        response["comparison"] = comparison
 
     _open_browser(url)
     click.echo(json.dumps(response))

--- a/src/agentcad/commands/view.py
+++ b/src/agentcad/commands/view.py
@@ -1988,7 +1988,15 @@ def _render_single(glb_path, *, review=None):
     return html_path, html_path.as_uri()
 
 
-def _render_diff(glb_a, glb_b, overlay=False, out_dir=None, review=None):
+def _render_diff(
+    glb_a,
+    glb_b,
+    overlay=False,
+    out_dir=None,
+    review=None,
+    diff_side_png=None,
+    diff_overlay_png=None,
+):
     """Write diff viewer HTML (with side-by-side or overlay as default).
 
     Returns (html_path, url, mode).
@@ -2004,17 +2012,23 @@ def _render_diff(glb_a, glb_b, overlay=False, out_dir=None, review=None):
         label_a=glb_a.name,
         label_b=glb_b.name,
         default_mode=mode,
+        diff_side_png=diff_side_png,
+        diff_overlay_png=diff_overlay_png,
         review=review,
     )
     return html_path, html_path.as_uri(), mode
+
+
+def _diff_png_path(glb_a, glb_b, out_dir):
+    label_a, label_b = _diff_name_parts(glb_a, glb_b)
+    return out_dir / f"diff_{label_a}_{label_b}.png"
 
 
 def _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir):
     """Render the side-by-side comparison PNG next to the diff HTML."""
     from agentcad.render import render_diff_side_by_side
 
-    label_a, label_b = _diff_name_parts(glb_a, glb_b)
-    png_path = out_dir / f"diff_{label_a}_{label_b}.png"
+    png_path = _diff_png_path(glb_a, glb_b, out_dir)
     render_diff_side_by_side(shape_a, shape_b, glb_a.name, glb_b.name, png_path)
     return png_path
 
@@ -2155,7 +2169,18 @@ def view(file, file_b, overlay, with_measure, spec_file):
     if err:
         _error(err)
 
-    html_path, url, mode = _render_diff(glb_a, glb_b, overlay=overlay, review=review)
+    out_dir = glb_a.parent
+    png_path = None
+    if shape_a is not None and shape_b is not None and not overlay:
+        png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, out_dir)
+
+    html_path, url, mode = _render_diff(
+        glb_a,
+        glb_b,
+        overlay=overlay,
+        review=review,
+        diff_side_png=png_path,
+    )
 
     response = {
         "command": "view",
@@ -2168,9 +2193,7 @@ def view(file, file_b, overlay, with_measure, spec_file):
     if review:
         response["review"] = True
 
-    # Agent-facing PNG composite (only when we have TopoDS shapes from STEP inputs)
-    if shape_a is not None and shape_b is not None and not overlay:
-        png_path = _render_diff_png(shape_a, shape_b, glb_a, glb_b, html_path.parent)
+    if png_path is not None:
         response["png"] = str(png_path)
 
     _open_browser(url)

--- a/src/agentcad/render.py
+++ b/src/agentcad/render.py
@@ -238,6 +238,86 @@ _COMPOSITE_VIEWS = [
 ]
 
 
+def _image_label_font(size):
+    from PIL import ImageFont
+
+    try:
+        return ImageFont.truetype("DejaVuSans.ttf", size=size)
+    except OSError:
+        try:
+            return ImageFont.load_default(size=size)
+        except TypeError:
+            return ImageFont.load_default()
+
+
+def _projected_shape_extent(shape, view_spec):
+    from OCP.Bnd import Bnd_Box
+    from OCP.BRepBndLib import BRepBndLib
+
+    bbox = Bnd_Box()
+    BRepBndLib.AddOptimal_s(shape, bbox)
+    xmin, ymin, zmin, xmax, ymax, zmax = bbox.Get()
+    dimensions = (xmax - xmin, ymax - ymin, zmax - zmin)
+
+    if view_spec == "top":
+        return max(dimensions[0], dimensions[1])
+
+    azimuth, elevation = view_spec
+    az_r = math.radians(azimuth)
+    el_r = math.radians(elevation)
+    direction = (
+        -math.sin(az_r) * math.cos(el_r),
+        math.cos(az_r) * math.cos(el_r),
+        -math.sin(el_r),
+    )
+    right = (direction[1], -direction[0], 0.0)
+    right_length = math.hypot(right[0], right[1])
+    right = (right[0] / right_length, right[1] / right_length, 0.0)
+    up = (
+        right[1] * direction[2],
+        -right[0] * direction[2],
+        right[0] * direction[1] - right[1] * direction[0],
+    )
+
+    half = tuple(value / 2 for value in dimensions)
+    corners = [
+        (x, y, z)
+        for x in (-half[0], half[0])
+        for y in (-half[1], half[1])
+        for z in (-half[2], half[2])
+    ]
+    horizontal = [sum(point[i] * right[i] for i in range(3)) for point in corners]
+    vertical = [sum(point[i] * up[i] for i in range(3)) for point in corners]
+    return max(max(horizontal) - min(horizontal), max(vertical) - min(vertical))
+
+
+def _comparison_frame_scales(shape_a, shape_b, view_spec):
+    extent_a = _projected_shape_extent(shape_a, view_spec)
+    extent_b = _projected_shape_extent(shape_b, view_spec)
+    common_extent = max(extent_a, extent_b)
+    if common_extent <= 0:
+        return 1.0, 1.0
+    return extent_a / common_extent, extent_b / common_extent
+
+
+def _scale_image_about_center(image, scale):
+    from PIL import Image
+
+    if scale >= 0.999:
+        return image
+    scaled_size = (
+        max(1, round(image.width * scale)),
+        max(1, round(image.height * scale)),
+    )
+    resized = image.resize(scaled_size, Image.Resampling.LANCZOS)
+    framed = Image.new("RGB", image.size, image.getpixel((0, 0)))
+    framed.paste(
+        resized,
+        ((image.width - resized.width) // 2, (image.height - resized.height) // 2),
+    )
+    return framed
+
+
 def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
     """Render a 4-panel composite: top view + three iso angles spaced around the part.
 
@@ -257,7 +337,8 @@ def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
 
         imgs = [Image.open(p).convert("RGB") for p in tmp_paths]
         w, h = per_view_size, per_view_size
-        label_h = 22
+        label_h = 30
+        label_font = _image_label_font(18)
         composite = Image.new("RGB", (w * 2, (h + label_h) * 2), (245, 245, 245))
 
         # 2x2 grid in row-major order
@@ -267,7 +348,7 @@ def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
 
         draw = ImageDraw.Draw(composite)
         for (x, y), label in zip(positions, labels):
-            draw.text((x + 10, y + 4), label, fill=(40, 40, 40))
+            draw.text((x + 10, y + 4), label, fill=(40, 40, 40), font=label_font)
         # Dividers
         draw.line([(w, 0), (w, (h + label_h) * 2)], fill=(200, 200, 200), width=1)
         draw.line([(0, h + label_h), (w * 2, h + label_h)], fill=(200, 200, 200), width=1)
@@ -278,48 +359,103 @@ def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
 def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
                         width=1024, height=1024, view_name="iso",
                         parts_a=None, parts_b=None):
-    """Render a tinted overlay of two shapes: A in green, B in red, alpha-blended.
+    """Render four center-aligned tinted overlays of A (green) and B (red).
 
-    Each shape is rendered independently (necessary — OCP V3d_View can't render
-    two shapes with different materials in one pass reliably), then PIL
-    composites them with alpha blending. Depth ordering is approximate — when
-    shapes partially occlude each other, the overlay is visually approximate
-    but usually still readable.
+    Each shape is fit independently for the same camera direction, which
+    removes unrelated source-coordinate offsets before compositing. Depth
+    ordering is approximate because the two captures are alpha-blended.
     """
     import tempfile
     from PIL import Image, ImageChops, ImageDraw
 
+    del view_name  # Diff artifacts always use the standard four comparison views.
+    labels = [view[0] for view in _COMPOSITE_VIEWS]
+    specs = [view[1] for view in _COMPOSITE_VIEWS]
+    per_view_size = max(64, min(width, height) // 2)
+    label_h = 30
+    legend_h = 72
+    label_font = _image_label_font(18)
+    legend_font = _image_label_font(18)
+
     with tempfile.TemporaryDirectory() as tmp:
-        a_path = Path(tmp) / "a.png"
-        b_path = Path(tmp) / "b.png"
-        # Same viewer setup for both since shapes differ — accept the cost
-        render_shape(
-            shape_a, view_name, a_path, width=width, height=height, parts=parts_a
+        a_paths = [Path(tmp) / f"a_{i}.png" for i in range(len(specs))]
+        b_paths = [Path(tmp) / f"b_{i}.png" for i in range(len(specs))]
+        render_shape_batch(
+            shape_a,
+            specs,
+            a_paths,
+            width=per_view_size,
+            height=per_view_size,
+            parts=parts_a,
         )
-        render_shape(
-            shape_b, view_name, b_path, width=width, height=height, parts=parts_b
+        render_shape_batch(
+            shape_b,
+            specs,
+            b_paths,
+            width=per_view_size,
+            height=per_view_size,
+            parts=parts_b,
         )
 
-        a_img = Image.open(a_path).convert("RGB")
-        b_img = Image.open(b_path).convert("RGB")
-
-        # Tint each: A green, B red. Multiply-blend gray renders with tint.
         def tint(img, tint_color):
             tint_layer = Image.new("RGB", img.size, tint_color)
             return ImageChops.multiply(img, tint_layer)
 
-        a_tinted = tint(a_img, (180, 255, 180))   # greenish
-        b_tinted = tint(b_img, (255, 180, 180))   # reddish
+        panels = []
+        for a_path, b_path, spec in zip(a_paths, b_paths, specs):
+            a_img = Image.open(a_path).convert("RGB")
+            b_img = Image.open(b_path).convert("RGB")
+            scale_a, scale_b = _comparison_frame_scales(shape_a, shape_b, spec)
+            a_img = _scale_image_about_center(a_img, scale_a)
+            b_img = _scale_image_about_center(b_img, scale_b)
+            a_tinted = tint(a_img, (180, 255, 180))
+            b_tinted = tint(b_img, (255, 180, 180))
+            panels.append(Image.blend(a_tinted, b_tinted, 0.5))
 
-        # Blend 50/50
-        composite = Image.blend(a_tinted, b_tinted, 0.5)
+        panel_stride = per_view_size + label_h
+        composite = Image.new(
+            "RGB",
+            (per_view_size * 2, legend_h + panel_stride * 2),
+            (245, 245, 245),
+        )
+        positions = [
+            (0, legend_h),
+            (per_view_size, legend_h),
+            (0, legend_h + panel_stride),
+            (per_view_size, legend_h + panel_stride),
+        ]
+        for panel, (x, y) in zip(panels, positions):
+            composite.paste(panel, (x, y + label_h))
 
-        # Legend
         draw = ImageDraw.Draw(composite)
-        draw.rectangle([(10, 10), (26, 26)], fill=(120, 200, 120))
-        draw.text((32, 10), f"A (prev) · {label_a}", fill=(40, 40, 40))
-        draw.rectangle([(10, 32), (26, 48)], fill=(220, 120, 120))
-        draw.text((32, 32), f"B (this) · {label_b}", fill=(40, 40, 40))
+        draw.rectangle([(10, 9), (29, 28)], fill=(120, 200, 120))
+        draw.text(
+            (38, 8),
+            f"A (previous) · {label_a}",
+            fill=(40, 40, 40),
+            font=legend_font,
+        )
+        draw.rectangle([(10, 41), (29, 60)], fill=(220, 120, 120))
+        draw.text(
+            (38, 40),
+            f"B (current) · {label_b}",
+            fill=(40, 40, 40),
+            font=legend_font,
+        )
+        for (x, y), label in zip(positions, labels):
+            draw.text((x + 10, y + 4), label, fill=(40, 40, 40), font=label_font)
+        divider_x = per_view_size
+        divider_y = legend_h + panel_stride
+        draw.line(
+            [(divider_x, legend_h), (divider_x, composite.height)],
+            fill=(200, 200, 200),
+            width=1,
+        )
+        draw.line(
+            [(0, divider_y), (composite.width, divider_y)],
+            fill=(200, 200, 200),
+            width=1,
+        )
 
         composite.save(str(output_path))
 
@@ -327,25 +463,29 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
 def render_diff_side_by_side(shape_a, shape_b, label_a, label_b, output_path,
                              width=512, height=512, view_name="iso",
                              parts_a=None, parts_b=None):
-    """Render two shapes side-by-side as a single comparison PNG.
-
-    Renders each shape independently from the same view, then composites them
-    horizontally with labels above each. Designed for agents that need a single
-    image to reason about what changed between two versions.
-    """
+    """Render standard four-view composites for A and B side-by-side."""
     import tempfile
     from PIL import Image, ImageDraw
 
-    label_h = 28  # pixels reserved above each render for the label bar
+    del view_name  # Diff artifacts always use the standard four comparison views.
+    label_h = 36
+    label_font = _image_label_font(20)
+    per_view_size = max(64, min(width, height))
 
     with tempfile.TemporaryDirectory() as tmp:
         a_path = Path(tmp) / "a.png"
         b_path = Path(tmp) / "b.png"
-        render_shape(
-            shape_a, view_name, a_path, width=width, height=height, parts=parts_a
+        render_composite_4view(
+            shape_a,
+            a_path,
+            per_view_size=per_view_size,
+            parts=parts_a,
         )
-        render_shape(
-            shape_b, view_name, b_path, width=width, height=height, parts=parts_b
+        render_composite_4view(
+            shape_b,
+            b_path,
+            per_view_size=per_view_size,
+            parts=parts_b,
         )
 
         a_img = Image.open(a_path).convert("RGB")
@@ -358,10 +498,15 @@ def render_diff_side_by_side(shape_a, shape_b, label_a, label_b, output_path,
         composite.paste(b_img, (a_img.width, label_h))
 
         draw = ImageDraw.Draw(composite)
-        # Labels — PIL's default font is small but always available
-        draw.text((12, 6), f"A · {label_a}", fill=(40, 40, 40))
-        draw.text((a_img.width + 12, 6), f"B · {label_b}", fill=(40, 40, 40))
-        # Thin divider between the two renders
+        draw.text(
+            (12, 5), f"A (previous) · {label_a}", fill=(40, 40, 40), font=label_font
+        )
+        draw.text(
+            (a_img.width + 12, 5),
+            f"B (current) · {label_b}",
+            fill=(40, 40, 40),
+            font=label_font,
+        )
         divider_x = a_img.width
         draw.line([(divider_x, 0), (divider_x, composite_h)], fill=(180, 180, 180), width=1)
 

--- a/src/agentcad/render.py
+++ b/src/agentcad/render.py
@@ -5,6 +5,7 @@ from OCP.AIS import AIS_InteractiveContext, AIS_Shape
 from OCP.Aspect import Aspect_DisplayConnection, Aspect_NeutralWindow
 from OCP.Graphic3d import (
     Graphic3d_MaterialAspect,
+    Graphic3d_NameOfMaterial_Plastered,
     Graphic3d_NameOfMaterial_Silver,
 )
 from OCP.Image import Image_AlienPixMap
@@ -131,12 +132,22 @@ def _setup_render(shape, width=800, height=600, parts=None, msaa=0):
         part_shape = part.get("topo_shape")
         if part_shape is None:
             continue
-        part_items.append((part_shape, _parse_color(part.get("color")), idx))
+        part_items.append((
+            part_shape,
+            _parse_color(part.get("color")),
+            idx,
+            part.get("material"),
+        ))
 
     if part_items:
-        for part_shape, parsed_color, idx in part_items:
+        for part_shape, parsed_color, idx, material in part_items:
             ais_shape = AIS_Shape(part_shape)
-            ais_shape.SetMaterial(Graphic3d_MaterialAspect(Graphic3d_NameOfMaterial_Silver))
+            material_name = (
+                Graphic3d_NameOfMaterial_Plastered
+                if material == "matte"
+                else Graphic3d_NameOfMaterial_Silver
+            )
+            ais_shape.SetMaterial(Graphic3d_MaterialAspect(material_name))
             r, g, b = parsed_color or _GLB_PALETTE[idx % len(_GLB_PALETTE)]
             ais_shape.SetColor(Quantity_Color(r, g, b, Quantity_TOC_RGB))
             context.Display(ais_shape, 1, -1, False)
@@ -390,9 +401,18 @@ def _semantic_diff_panel(image_a, image_b):
     added_pixels = _mask_pixel_count(added)
     denominator = union_pixels or 1
     return panel, {
-        "overlap_ratio": round(shared_pixels / denominator, 4),
-        "removed_ratio": round(removed_pixels / denominator, 4),
-        "added_ratio": round(added_pixels / denominator, 4),
+        "coincident_fraction_of_union": round(
+            shared_pixels / denominator,
+            4,
+        ),
+        "reference_only_fraction_of_union": round(
+            removed_pixels / denominator,
+            4,
+        ),
+        "candidate_only_fraction_of_union": round(
+            added_pixels / denominator,
+            4,
+        ),
         "_shared_pixels": shared_pixels,
         "_union_pixels": union_pixels,
     }
@@ -444,13 +464,81 @@ def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
         composite.save(str(output_path))
 
 
+def render_solid_comparison(
+    shape,
+    parts,
+    output_path,
+    per_view_size=512,
+    comparison_data=None,
+):
+    """Render actual shared/reference-only/candidate-only 3D volumes."""
+    import tempfile
+    from PIL import Image, ImageDraw
+
+    legend_h = 132
+    legend_font = _image_label_font(18)
+    with tempfile.TemporaryDirectory() as tmp:
+        composite_path = Path(tmp) / "solid_comparison.png"
+        render_composite_4view(
+            shape,
+            composite_path,
+            per_view_size=per_view_size,
+            parts=parts,
+        )
+        with Image.open(composite_path) as source:
+            source = source.convert("RGB")
+            output = Image.new(
+                "RGB",
+                (source.width, source.height + legend_h),
+                (245, 245, 245),
+            )
+            output.paste(source, (0, legend_h))
+
+        draw = ImageDraw.Draw(output)
+        draw.text(
+            (10, 8),
+            "SOURCE-FRAME 3D VOLUME | NO ALIGNMENT APPLIED",
+            fill=(40, 40, 40),
+            font=legend_font,
+        )
+        volumes = (comparison_data or {}).get("volumes", {})
+        unit = (comparison_data or {}).get("units", {}).get("volume")
+
+        def _legend_text(label, key):
+            if key not in volumes or not unit:
+                return label
+            return f"{label} | {volumes[key]:,.4f} {unit}"
+
+        legend = (
+            (
+                (210, 214, 220),
+                _legend_text("SHARED 3D VOLUME", "shared"),
+            ),
+            (
+                (0, 114, 178),
+                _legend_text("REFERENCE-ONLY 3D VOLUME", "reference_only"),
+            ),
+            (
+                (230, 159, 0),
+                _legend_text("CANDIDATE-ONLY 3D VOLUME", "candidate_only"),
+            ),
+        )
+        for index, (color, label) in enumerate(legend):
+            y = 40 + index * 30
+            draw.rectangle([(10, y + 1), (29, y + 20)], fill=color)
+            draw.text((38, y), label, fill=(40, 40, 40), font=legend_font)
+
+        output.save(str(output_path))
+
+
 def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
                         width=1024, height=1024, view_name="iso",
                         parts_a=None, parts_b=None):
     """Render four center-aligned semantic difference maps.
 
-    Shared projection is gray, A-only geometry is blue, and B-only geometry is
-    orange. The return value describes the same masks used to make the image.
+    Coincident projection is gray, A-only projected pixels are blue, and
+    B-only projected pixels are orange. The return value describes the same
+    masks used to make the image.
     """
     import tempfile
     from PIL import Image, ImageDraw
@@ -518,26 +606,26 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
         draw.rectangle([(10, 9), (29, 28)], fill=(210, 214, 220))
         draw.text(
             (38, 8),
-            "SHARED PROJECTION",
+            "COINCIDENT PROJECTED PIXELS",
             fill=(40, 40, 40),
             font=legend_font,
         )
         draw.rectangle([(10, 41), (29, 60)], fill=(0, 114, 178))
         draw.text(
             (38, 40),
-            f"REMOVED | A (previous) | {label_a}",
+            f"REFERENCE-ONLY PROJECTION | A (previous) | {label_a}",
             fill=(40, 40, 40),
             font=legend_font,
         )
         draw.rectangle([(10, 73), (29, 92)], fill=(230, 159, 0))
         draw.text(
             (38, 72),
-            f"ADDED | B (current) | {label_b}",
+            f"CANDIDATE-ONLY PROJECTION | B (current) | {label_b}",
             fill=(40, 40, 40),
             font=legend_font,
         )
         for (x, y), label, stats in zip(positions, labels, view_stats):
-            overlap = round(stats["overlap_ratio"] * 100)
+            overlap = round(stats["coincident_fraction_of_union"] * 100)
             draw.text(
                 (x + 10, y + 5),
                 f"{label} | OVERLAP {overlap}%",
@@ -564,15 +652,22 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
     overlap_ratio = round(shared_pixels / (union_pixels or 1), 4)
     return {
         "method": "four_view_image_mask",
+        "scope": "2d_projected_pixels",
         "alignment": {
             "mode": "bounding_box_center",
             "rotation": "preserved",
             "relative_scale": "preserved",
         },
-        "visual_overlap": {
-            "ratio": overlap_ratio,
+        "score": {
+            "metric": "projection_intersection_over_union",
+            "value": overlap_ratio,
             "classification": _overlap_classification(overlap_ratio),
+            "aggregation": "foreground_union_pixel_weighted_across_views",
         },
+        "limitations": [
+            "Does not establish shared 3D geometry.",
+            "Does not identify physical material additions or removals.",
+        ],
         "views": view_stats,
     }
 

--- a/src/agentcad/render.py
+++ b/src/agentcad/render.py
@@ -318,6 +318,94 @@ def _scale_image_about_center(image, scale):
     return framed
 
 
+def _object_mask(image, threshold=8):
+    from PIL import Image, ImageChops
+
+    corners = [
+        image.getpixel((0, 0)),
+        image.getpixel((image.width - 1, 0)),
+        image.getpixel((0, image.height - 1)),
+        image.getpixel((image.width - 1, image.height - 1)),
+    ]
+    background = tuple(
+        round(sum(pixel[channel] for pixel in corners) / len(corners))
+        for channel in range(3)
+    )
+    difference = ImageChops.difference(
+        image, Image.new("RGB", image.size, background)
+    ).convert("L")
+    return difference.point(lambda value: 255 if value > threshold else 0)
+
+
+def _edge_mask(image, object_mask):
+    from PIL import ImageChops, ImageFilter
+
+    boundary = ImageChops.subtract(
+        object_mask.filter(ImageFilter.MaxFilter(5)),
+        object_mask.filter(ImageFilter.MinFilter(5)),
+    )
+    gradients = (
+        image.convert("L")
+        .filter(ImageFilter.GaussianBlur(radius=0.6))
+        .filter(ImageFilter.FIND_EDGES)
+        .point(lambda value: 255 if value > 18 else 0)
+    )
+    surface_edges = ImageChops.multiply(
+        gradients, object_mask.filter(ImageFilter.MaxFilter(3))
+    )
+    return ImageChops.lighter(boundary, surface_edges)
+
+
+def _mask_pixel_count(mask):
+    return mask.histogram()[255]
+
+
+def _semantic_diff_panel(image_a, image_b):
+    from PIL import Image, ImageChops
+
+    mask_a = _object_mask(image_a)
+    mask_b = _object_mask(image_b)
+    shared = ImageChops.multiply(mask_a, mask_b)
+    removed = ImageChops.subtract(mask_a, mask_b)
+    added = ImageChops.subtract(mask_b, mask_a)
+    union = ImageChops.lighter(mask_a, mask_b)
+
+    edge_a = _edge_mask(image_a, mask_a)
+    edge_b = _edge_mask(image_b, mask_b)
+    shared_edges = ImageChops.multiply(edge_a, edge_b)
+    removed_edges = ImageChops.subtract(edge_a, edge_b)
+    added_edges = ImageChops.subtract(edge_b, edge_a)
+
+    panel = Image.new("RGB", image_a.size, (255, 255, 255))
+    panel.paste((210, 214, 220), mask=shared)
+    panel.paste((0, 114, 178), mask=removed)
+    panel.paste((230, 159, 0), mask=added)
+    panel.paste((0, 62, 105), mask=removed_edges)
+    panel.paste((145, 82, 0), mask=added_edges)
+    panel.paste((55, 65, 81), mask=shared_edges)
+
+    union_pixels = _mask_pixel_count(union)
+    shared_pixels = _mask_pixel_count(shared)
+    removed_pixels = _mask_pixel_count(removed)
+    added_pixels = _mask_pixel_count(added)
+    denominator = union_pixels or 1
+    return panel, {
+        "overlap_ratio": round(shared_pixels / denominator, 4),
+        "removed_ratio": round(removed_pixels / denominator, 4),
+        "added_ratio": round(added_pixels / denominator, 4),
+        "_shared_pixels": shared_pixels,
+        "_union_pixels": union_pixels,
+    }
+
+
+def _overlap_classification(ratio):
+    if ratio >= 0.8:
+        return "high"
+    if ratio >= 0.5:
+        return "moderate"
+    return "low"
+
+
 def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
     """Render a 4-panel composite: top view + three iso angles spaced around the part.
 
@@ -359,21 +447,20 @@ def render_composite_4view(shape, output_path, per_view_size=512, parts=None):
 def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
                         width=1024, height=1024, view_name="iso",
                         parts_a=None, parts_b=None):
-    """Render four center-aligned tinted overlays of A (green) and B (red).
+    """Render four center-aligned semantic difference maps.
 
-    Each shape is fit independently for the same camera direction, which
-    removes unrelated source-coordinate offsets before compositing. Depth
-    ordering is approximate because the two captures are alpha-blended.
+    Shared projection is gray, A-only geometry is blue, and B-only geometry is
+    orange. The return value describes the same masks used to make the image.
     """
     import tempfile
-    from PIL import Image, ImageChops, ImageDraw
+    from PIL import Image, ImageDraw
 
     del view_name  # Diff artifacts always use the standard four comparison views.
     labels = [view[0] for view in _COMPOSITE_VIEWS]
     specs = [view[1] for view in _COMPOSITE_VIEWS]
     per_view_size = max(64, min(width, height) // 2)
-    label_h = 30
-    legend_h = 72
+    label_h = 34
+    legend_h = 108
     label_font = _image_label_font(18)
     legend_font = _image_label_font(18)
 
@@ -397,20 +484,20 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
             parts=parts_b,
         )
 
-        def tint(img, tint_color):
-            tint_layer = Image.new("RGB", img.size, tint_color)
-            return ImageChops.multiply(img, tint_layer)
-
         panels = []
-        for a_path, b_path, spec in zip(a_paths, b_paths, specs):
+        view_stats = []
+        for label, a_path, b_path, spec in zip(labels, a_paths, b_paths, specs):
             a_img = Image.open(a_path).convert("RGB")
             b_img = Image.open(b_path).convert("RGB")
             scale_a, scale_b = _comparison_frame_scales(shape_a, shape_b, spec)
             a_img = _scale_image_about_center(a_img, scale_a)
             b_img = _scale_image_about_center(b_img, scale_b)
-            a_tinted = tint(a_img, (180, 255, 180))
-            b_tinted = tint(b_img, (255, 180, 180))
-            panels.append(Image.blend(a_tinted, b_tinted, 0.5))
+            panel, stats = _semantic_diff_panel(a_img, b_img)
+            panels.append(panel)
+            view_stats.append({
+                "view": label.lower().replace(" ", "_").replace("-", "_"),
+                **stats,
+            })
 
         panel_stride = per_view_size + label_h
         composite = Image.new(
@@ -428,22 +515,35 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
             composite.paste(panel, (x, y + label_h))
 
         draw = ImageDraw.Draw(composite)
-        draw.rectangle([(10, 9), (29, 28)], fill=(120, 200, 120))
+        draw.rectangle([(10, 9), (29, 28)], fill=(210, 214, 220))
         draw.text(
             (38, 8),
-            f"A (previous) · {label_a}",
+            "SHARED PROJECTION",
             fill=(40, 40, 40),
             font=legend_font,
         )
-        draw.rectangle([(10, 41), (29, 60)], fill=(220, 120, 120))
+        draw.rectangle([(10, 41), (29, 60)], fill=(0, 114, 178))
         draw.text(
             (38, 40),
-            f"B (current) · {label_b}",
+            f"REMOVED | A (previous) | {label_a}",
             fill=(40, 40, 40),
             font=legend_font,
         )
-        for (x, y), label in zip(positions, labels):
-            draw.text((x + 10, y + 4), label, fill=(40, 40, 40), font=label_font)
+        draw.rectangle([(10, 73), (29, 92)], fill=(230, 159, 0))
+        draw.text(
+            (38, 72),
+            f"ADDED | B (current) | {label_b}",
+            fill=(40, 40, 40),
+            font=legend_font,
+        )
+        for (x, y), label, stats in zip(positions, labels, view_stats):
+            overlap = round(stats["overlap_ratio"] * 100)
+            draw.text(
+                (x + 10, y + 5),
+                f"{label} | OVERLAP {overlap}%",
+                fill=(40, 40, 40),
+                font=label_font,
+            )
         divider_x = per_view_size
         divider_y = legend_h + panel_stride
         draw.line(
@@ -458,6 +558,23 @@ def render_diff_overlay(shape_a, shape_b, label_a, label_b, output_path,
         )
 
         composite.save(str(output_path))
+
+    shared_pixels = sum(stats.pop("_shared_pixels") for stats in view_stats)
+    union_pixels = sum(stats.pop("_union_pixels") for stats in view_stats)
+    overlap_ratio = round(shared_pixels / (union_pixels or 1), 4)
+    return {
+        "method": "four_view_image_mask",
+        "alignment": {
+            "mode": "bounding_box_center",
+            "rotation": "preserved",
+            "relative_scale": "preserved",
+        },
+        "visual_overlap": {
+            "ratio": overlap_ratio,
+            "classification": _overlap_classification(overlap_ratio),
+        },
+        "views": view_stats,
+    }
 
 
 def render_diff_side_by_side(shape_a, shape_b, label_a, label_b, output_path,

--- a/src/agentcad/solid_compare.py
+++ b/src/agentcad/solid_compare.py
@@ -1,0 +1,333 @@
+"""Source-frame volumetric comparison for closed CAD solids."""
+
+from dataclasses import dataclass
+
+from OCP.BRep import BRep_Builder
+from OCP.BRepAlgoAPI import BRepAlgoAPI_Common, BRepAlgoAPI_Cut
+from OCP.BRepCheck import BRepCheck_Analyzer
+from OCP.BRepGProp import BRepGProp
+from OCP.GProp import GProp_GProps
+from OCP.TopAbs import TopAbs_SOLID
+from OCP.TopExp import TopExp_Explorer
+from OCP.TopoDS import TopoDS_Compound
+
+
+_DEFAULT_TOLERANCE_MM = 1e-7
+_SHARED_COLOR = "#d2d6dc"
+_REFERENCE_ONLY_COLOR = "#0072b2"
+_CANDIDATE_ONLY_COLOR = "#e69f00"
+
+
+@dataclass
+class SolidComparison:
+    """JSON result plus the derived shapes used for visual artifacts."""
+
+    data: dict
+    shared_shape: object | None = None
+    reference_only_shape: object | None = None
+    candidate_only_shape: object | None = None
+
+    @property
+    def available(self):
+        return self.data["status"] == "success"
+
+    def colored_parts(self):
+        if not self.available:
+            return []
+
+        volumes = self.data["volumes"]
+        parts = []
+        for part_id, name, color, shape, volume_key in (
+            (
+                "shared_volume",
+                "Shared 3D volume",
+                _SHARED_COLOR,
+                self.shared_shape,
+                "shared",
+            ),
+            (
+                "reference_only_volume",
+                "Reference-only 3D volume",
+                _REFERENCE_ONLY_COLOR,
+                self.reference_only_shape,
+                "reference_only",
+            ),
+            (
+                "candidate_only_volume",
+                "Candidate-only 3D volume",
+                _CANDIDATE_ONLY_COLOR,
+                self.candidate_only_shape,
+                "candidate_only",
+            ),
+        ):
+            if shape is not None and volumes[volume_key] > 0:
+                parts.append({
+                    "id": part_id,
+                    "name": name,
+                    "color": color,
+                    "material": "matte",
+                    "topo_shape": shape,
+                })
+        return parts
+
+    def compound_shape(self):
+        parts = self.colored_parts()
+        if not parts:
+            return None
+
+        compound = TopoDS_Compound()
+        builder = BRep_Builder()
+        builder.MakeCompound(compound)
+        for part in parts:
+            builder.Add(compound, part["topo_shape"])
+        return compound
+
+
+def _solid_count(shape):
+    count = 0
+    explorer = TopExp_Explorer(shape, TopAbs_SOLID)
+    while explorer.More():
+        count += 1
+        explorer.Next()
+    return count
+
+
+def _volume(shape):
+    props = GProp_GProps()
+    BRepGProp.VolumeProperties_s(shape, props)
+    return props.Mass()
+
+
+def _base_response(tolerance_mm):
+    return {
+        "method": "source_frame_boolean_volume",
+        "alignment": {
+            "mode": "source_frame",
+            "transform_applied": False,
+        },
+        "units": {
+            "length": "mm",
+            "volume": "mm^3",
+        },
+        "tolerance": {
+            "linear": tolerance_mm,
+            "unit": "mm",
+        },
+    }
+
+
+def _unavailable(tolerance_mm, code, message):
+    return SolidComparison({
+        **_base_response(tolerance_mm),
+        "status": "unavailable",
+        "reason": {
+            "code": code,
+            "message": message,
+        },
+    })
+
+
+def _run_boolean(operation_type, shape_a, shape_b, tolerance_mm):
+    operation = operation_type(shape_a, shape_b)
+    operation.SetFuzzyValue(tolerance_mm)
+    operation.Build()
+    if not operation.IsDone():
+        raise RuntimeError(f"{operation_type.__name__} did not complete")
+    result = operation.Shape()
+    if result.IsNull():
+        raise RuntimeError(f"{operation_type.__name__} produced a null shape")
+    return result
+
+
+def _round_volume(value):
+    rounded = round(value, 4)
+    return 0.0 if rounded == 0 else rounded
+
+
+def _round_ratio(value):
+    rounded = round(value, 4)
+    return 0.0 if rounded == 0 else rounded
+
+
+def compare_solid_volumes(
+    reference_shape,
+    candidate_shape,
+    *,
+    tolerance_mm=_DEFAULT_TOLERANCE_MM,
+):
+    """Compare actual occupied volume without moving either input shape.
+
+    Returns a successful ``SolidComparison`` only for valid shapes containing
+    at least one closed solid. Boolean failures are represented as structured
+    ``status=unavailable`` results so a normal diff can continue.
+    """
+    for role, shape in (
+        ("reference", reference_shape),
+        ("candidate", candidate_shape),
+    ):
+        if _solid_count(shape) == 0:
+            return _unavailable(
+                tolerance_mm,
+                f"{role}_has_no_closed_solid",
+                f"The {role} contains no closed solid volume.",
+            )
+        if not BRepCheck_Analyzer(shape).IsValid():
+            return _unavailable(
+                tolerance_mm,
+                f"{role}_is_invalid",
+                f"The {role} is not a valid B-rep solid.",
+            )
+
+    reference_volume = _volume(reference_shape)
+    candidate_volume = _volume(candidate_shape)
+    if reference_volume <= 0:
+        return _unavailable(
+            tolerance_mm,
+            "reference_has_no_positive_volume",
+            "The reference has no positive solid volume.",
+        )
+    if candidate_volume <= 0:
+        return _unavailable(
+            tolerance_mm,
+            "candidate_has_no_positive_volume",
+            "The candidate has no positive solid volume.",
+        )
+
+    try:
+        shared_shape = _run_boolean(
+            BRepAlgoAPI_Common,
+            reference_shape,
+            candidate_shape,
+            tolerance_mm,
+        )
+        reference_only_shape = _run_boolean(
+            BRepAlgoAPI_Cut,
+            reference_shape,
+            candidate_shape,
+            tolerance_mm,
+        )
+        candidate_only_shape = _run_boolean(
+            BRepAlgoAPI_Cut,
+            candidate_shape,
+            reference_shape,
+            tolerance_mm,
+        )
+    except Exception as exc:
+        return _unavailable(
+            tolerance_mm,
+            "boolean_operation_failed",
+            f"OpenCascade could not complete the solid comparison: {exc}",
+        )
+
+    for name, shape in (
+        ("shared", shared_shape),
+        ("reference-only", reference_only_shape),
+        ("candidate-only", candidate_only_shape),
+    ):
+        if not BRepCheck_Analyzer(shape).IsValid():
+            return _unavailable(
+                tolerance_mm,
+                "boolean_result_invalid",
+                f"The {name} Boolean result is not a valid B-rep.",
+            )
+
+    shared_volume = max(0.0, _volume(shared_shape))
+    reference_only_volume = max(0.0, _volume(reference_only_shape))
+    candidate_only_volume = max(0.0, _volume(candidate_only_shape))
+    union_volume = reference_volume + candidate_volume - shared_volume
+
+    conservation_tolerance = max(
+        1e-4,
+        max(reference_volume, candidate_volume) * 1e-6,
+    )
+    reference_error = abs(
+        reference_volume - (shared_volume + reference_only_volume)
+    )
+    candidate_error = abs(
+        candidate_volume - (shared_volume + candidate_only_volume)
+    )
+    if max(reference_error, candidate_error) > conservation_tolerance:
+        return _unavailable(
+            tolerance_mm,
+            "volume_conservation_failed",
+            "Boolean results did not conserve the input solid volumes.",
+        )
+
+    classification_tolerance = max(
+        1e-6,
+        max(reference_volume, candidate_volume) * 1e-12,
+    )
+    if shared_volume <= classification_tolerance:
+        classification = "no_shared_volume"
+    elif (
+        reference_only_volume <= classification_tolerance
+        and candidate_only_volume <= classification_tolerance
+    ):
+        classification = "same_occupied_volume"
+    else:
+        classification = "partial_shared_volume"
+
+    data = {
+        **_base_response(tolerance_mm),
+        "status": "success",
+        "classification": classification,
+        "volumes": {
+            "reference": _round_volume(reference_volume),
+            "candidate": _round_volume(candidate_volume),
+            "shared": _round_volume(shared_volume),
+            "reference_only": _round_volume(reference_only_volume),
+            "candidate_only": _round_volume(candidate_only_volume),
+            "union": _round_volume(union_volume),
+        },
+        "ratios": {
+            "volume_iou": _round_ratio(shared_volume / union_volume),
+            "reference_coverage": _round_ratio(
+                shared_volume / reference_volume
+            ),
+            "candidate_coverage": _round_ratio(
+                shared_volume / candidate_volume
+            ),
+        },
+        "meaning": {
+            "shared": "Physical volume occupied by both models.",
+            "reference_only": (
+                "Physical volume occupied only by the reference."
+            ),
+            "candidate_only": (
+                "Physical volume occupied only by the candidate."
+            ),
+        },
+        "limitations": [
+            "Models were compared at the positions stored in their files.",
+            "No translation, rotation, scaling, or automatic matching was applied.",
+        ],
+    }
+    return SolidComparison(
+        data,
+        shared_shape=shared_shape,
+        reference_only_shape=reference_only_shape,
+        candidate_only_shape=candidate_only_shape,
+    )
+
+
+def write_solid_comparison_artifacts(comparison, glb_path, png_path):
+    """Write a colored GLB and four-view PNG for a successful comparison."""
+    if not comparison.available:
+        return False
+
+    shape = comparison.compound_shape()
+    parts = comparison.colored_parts()
+    if shape is None or not parts:
+        return False
+
+    from agentcad.export import export_glb
+    from agentcad.render import render_solid_comparison
+
+    export_glb(shape, glb_path, parts=parts)
+    render_solid_comparison(
+        shape,
+        parts,
+        png_path,
+        comparison_data=comparison.data,
+    )
+    return True

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,7 +1,15 @@
 import json
 
+import cadquery as cq
+from cadquery import exporters
 from click.testing import CliRunner
 from agentcad.cli import cli
+
+
+def _write_box_step(path, size):
+    box = cq.Workplane("XY").box(size, size, size)
+    exporters.export(box, str(path))
+    return path
 
 
 def _setup_two_versions(isolated_dir):
@@ -52,6 +60,36 @@ def test_diff_no_manifest_error(runner, isolated_dir):
     data = json.loads(result.stdout)
     assert data["command"] == "diff"
     assert data["status"] == "error"
+
+
+def test_diff_accepts_standalone_step_paths_without_manifest(runner, isolated_dir):
+    input_step = _write_box_step(isolated_dir / "input.step", 10)
+    output_step = _write_box_step(isolated_dir / "output.step", 20)
+
+    result = runner.invoke(cli, ["diff", str(input_step), str(output_step)])
+
+    assert result.exit_code == 0, result.output
+    data = json.loads(result.stdout)
+    assert data["status"] == "success"
+    assert data["v1"]["file"] == "input.step"
+    assert data["v2"]["file"] == "output.step"
+    assert data["changes"]["metrics"]["volume"] == {"from": 1000.0, "to": 8000.0}
+    assert data["changes"]["metrics"]["dimensions"] == {
+        "from": {"x": 10.0, "y": 10.0, "z": 10.0},
+        "to": {"x": 20.0, "y": 20.0, "z": 20.0},
+    }
+
+
+def test_diff_standalone_step_path_missing_file_error(runner, isolated_dir):
+    input_step = _write_box_step(isolated_dir / "input.step", 10)
+
+    result = runner.invoke(cli, ["diff", str(input_step), "missing.step"])
+
+    assert result.exit_code == 1
+    data = json.loads(result.stdout)
+    assert data["command"] == "diff"
+    assert data["status"] == "error"
+    assert data["message"] == "File 'missing.step' not found."
 
 
 def test_diff_by_version_number(runner, isolated_dir):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -78,6 +78,17 @@ def test_diff_accepts_standalone_step_paths_without_manifest(runner, isolated_di
         "from": {"x": 10.0, "y": 10.0, "z": 10.0},
         "to": {"x": 20.0, "y": 20.0, "z": 20.0},
     }
+    comparison = data["comparison_3d"]
+    assert comparison["method"] == "source_frame_boolean_volume"
+    assert comparison["alignment"] == {
+        "mode": "source_frame",
+        "transform_applied": False,
+    }
+    assert comparison["volumes"]["shared"] == 1000.0
+    assert comparison["volumes"]["reference_only"] == 0.0
+    assert comparison["volumes"]["candidate_only"] == 7000.0
+    assert comparison["ratios"]["reference_coverage"] == 1.0
+    assert comparison["ratios"]["candidate_coverage"] == 0.125
 
 
 def test_diff_standalone_step_path_missing_file_error(runner, isolated_dir):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -172,6 +172,8 @@ class TestImportAutoDiff:
         parsed = json.loads(result.stdout)
         assert "diff" in parsed
         assert parsed["diff"]["against"] == "rev_a"
+        assert parsed["diff"]["comparison"]["method"] == "four_view_image_mask"
+        assert "visual_overlap" in parsed["diff"]["comparison"]
         side = isolated_dir / "v2_rev_b" / "diff_side.png"
         assert side.exists()
 

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -172,10 +172,18 @@ class TestImportAutoDiff:
         parsed = json.loads(result.stdout)
         assert "diff" in parsed
         assert parsed["diff"]["against"] == "rev_a"
-        assert parsed["diff"]["comparison"]["method"] == "four_view_image_mask"
-        assert "visual_overlap" in parsed["diff"]["comparison"]
+        projection = parsed["diff"]["projection_comparison"]
+        assert projection["method"] == "four_view_image_mask"
+        assert "score" in projection
+        assert (
+            parsed["diff"]["comparison_3d"]["method"]
+            == "source_frame_boolean_volume"
+        )
+        assert parsed["diff"]["comparison_3d"]["status"] == "success"
         side = isolated_dir / "v2_rev_b" / "diff_side.png"
         assert side.exists()
+        assert (isolated_dir / "v2_rev_b" / "diff_volume.png").exists()
+        assert (isolated_dir / "v2_rev_b" / "diff_volume.glb").exists()
 
 
 # --- non-Tier-0 inputs ------------------------------------------------------

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -6,7 +6,10 @@ from PIL import Image, ImageChops
 import pytest
 
 from agentcad.render import (
+    _comparison_frame_scales,
     _setup_render,
+    render_diff_overlay,
+    render_diff_side_by_side,
     render_shape,
     render_shape_batch,
     render_shape_custom,
@@ -82,6 +85,44 @@ def test_render_shape_different_views_differ(tmp_path):
     render_shape(shape, "iso", iso_path)
     render_shape(shape, "front", front_path)
     assert iso_path.read_bytes() != front_path.read_bytes()
+
+
+def test_render_diff_side_by_side_contains_four_views_per_shape(tmp_path):
+    shape_a = cq.Workplane("XY").box(10, 10, 10).val().wrapped
+    shape_b = cq.Workplane("XY").box(20, 10, 5).val().wrapped
+    output = tmp_path / "diff_side.png"
+
+    render_diff_side_by_side(
+        shape_a, shape_b, "previous", "current", output, width=96, height=96
+    )
+
+    with Image.open(output) as image:
+        # Two 2x2 composites, plus one shared model-label bar.
+        assert image.size == (384, 288)
+
+
+def test_render_diff_overlay_contains_four_aligned_views(tmp_path):
+    shape_a = cq.Workplane("XY").box(10, 10, 10).translate((0, 0, 50)).val().wrapped
+    shape_b = cq.Workplane("XY").box(20, 10, 5).val().wrapped
+    output = tmp_path / "diff_overlay.png"
+
+    render_diff_overlay(
+        shape_a, shape_b, "previous", "current", output, width=192, height=192
+    )
+
+    with Image.open(output) as image:
+        # A 2x2 grid of 96px overlays, with view labels and a shared legend.
+        assert image.size == (192, 324)
+
+
+def test_diff_overlay_preserves_relative_scale():
+    shape_a = cq.Workplane("XY").box(10, 10, 10).val().wrapped
+    shape_b = cq.Workplane("XY").box(20, 20, 20).val().wrapped
+
+    scale_a, scale_b = _comparison_frame_scales(shape_a, shape_b, "top")
+
+    assert scale_a == pytest.approx(0.5)
+    assert scale_b == pytest.approx(1.0)
 
 
 def test_render_views_returns_dict(tmp_path):

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -116,7 +116,7 @@ def test_render_diff_overlay_contains_four_aligned_views(tmp_path):
         assert image.size == (192, 368)
     assert comparison["method"] == "four_view_image_mask"
     assert comparison["alignment"]["mode"] == "bounding_box_center"
-    assert comparison["visual_overlap"]["classification"] in {
+    assert comparison["score"]["classification"] in {
         "low", "moderate", "high",
     }
     assert len(comparison["views"]) == 4
@@ -138,8 +138,8 @@ def test_render_diff_overlay_classifies_same_geometry_as_high_overlap(tmp_path):
         height=192,
     )
 
-    assert comparison["visual_overlap"]["classification"] == "high"
-    assert comparison["visual_overlap"]["ratio"] > 0.95
+    assert comparison["score"]["classification"] == "high"
+    assert comparison["score"]["value"] > 0.95
 
 
 def test_semantic_diff_panel_classifies_shared_removed_and_added_pixels():
@@ -150,9 +150,9 @@ def test_semantic_diff_panel_classifies_shared_removed_and_added_pixels():
 
     panel, stats = _semantic_diff_panel(image_a, image_b)
 
-    assert stats["overlap_ratio"] == pytest.approx(0.25)
-    assert stats["removed_ratio"] == pytest.approx(0.375)
-    assert stats["added_ratio"] == pytest.approx(0.375)
+    assert stats["coincident_fraction_of_union"] == pytest.approx(0.25)
+    assert stats["reference_only_fraction_of_union"] == pytest.approx(0.375)
+    assert stats["candidate_only_fraction_of_union"] == pytest.approx(0.375)
     pixels = (
         panel.get_flattened_data()
         if hasattr(panel, "get_flattened_data")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,12 +1,13 @@
 from pathlib import Path
 
 import cadquery as cq
-from PIL import Image, ImageChops
+from PIL import Image, ImageChops, ImageDraw
 
 import pytest
 
 from agentcad.render import (
     _comparison_frame_scales,
+    _semantic_diff_panel,
     _setup_render,
     render_diff_overlay,
     render_diff_side_by_side,
@@ -106,13 +107,61 @@ def test_render_diff_overlay_contains_four_aligned_views(tmp_path):
     shape_b = cq.Workplane("XY").box(20, 10, 5).val().wrapped
     output = tmp_path / "diff_overlay.png"
 
-    render_diff_overlay(
+    comparison = render_diff_overlay(
         shape_a, shape_b, "previous", "current", output, width=192, height=192
     )
 
     with Image.open(output) as image:
         # A 2x2 grid of 96px overlays, with view labels and a shared legend.
-        assert image.size == (192, 324)
+        assert image.size == (192, 368)
+    assert comparison["method"] == "four_view_image_mask"
+    assert comparison["alignment"]["mode"] == "bounding_box_center"
+    assert comparison["visual_overlap"]["classification"] in {
+        "low", "moderate", "high",
+    }
+    assert len(comparison["views"]) == 4
+
+
+def test_render_diff_overlay_classifies_same_geometry_as_high_overlap(tmp_path):
+    shape_a = cq.Workplane("XY").box(10, 20, 5).val().wrapped
+    shape_b = (
+        cq.Workplane("XY").box(10, 20, 5).translate((100, -50, 25)).val().wrapped
+    )
+
+    comparison = render_diff_overlay(
+        shape_a,
+        shape_b,
+        "previous",
+        "current",
+        tmp_path / "same_geometry.png",
+        width=192,
+        height=192,
+    )
+
+    assert comparison["visual_overlap"]["classification"] == "high"
+    assert comparison["visual_overlap"]["ratio"] > 0.95
+
+
+def test_semantic_diff_panel_classifies_shared_removed_and_added_pixels():
+    image_a = Image.new("RGB", (100, 100), (77, 77, 77))
+    image_b = Image.new("RGB", (100, 100), (77, 77, 77))
+    ImageDraw.Draw(image_a).rectangle((10, 20, 59, 79), fill=(180, 180, 180))
+    ImageDraw.Draw(image_b).rectangle((40, 20, 89, 79), fill=(180, 180, 180))
+
+    panel, stats = _semantic_diff_panel(image_a, image_b)
+
+    assert stats["overlap_ratio"] == pytest.approx(0.25)
+    assert stats["removed_ratio"] == pytest.approx(0.375)
+    assert stats["added_ratio"] == pytest.approx(0.375)
+    pixels = (
+        panel.get_flattened_data()
+        if hasattr(panel, "get_flattened_data")
+        else panel.getdata()
+    )
+    colors = set(pixels)
+    assert (210, 214, 220) in colors
+    assert (0, 114, 178) in colors
+    assert (230, 159, 0) in colors
 
 
 def test_diff_overlay_preserves_relative_scale():

--- a/tests/test_response_shapes.py
+++ b/tests/test_response_shapes.py
@@ -221,8 +221,10 @@ def test_diff_response_shape(runner, isolated_dir):
     r = runner.invoke(cli, ["diff", "1", "2"])
     assert r.exit_code == 0, r.output
     parsed = json.loads(r.stdout)
-    for key in ("command", "status", "v1", "v2", "changes"):
+    for key in ("command", "status", "v1", "v2", "changes", "comparison_3d"):
         assert key in parsed, f"`diff` missing required field: {key}"
+    assert parsed["comparison_3d"]["method"] == "source_frame_boolean_volume"
+    assert parsed["comparison_3d"]["alignment"]["transform_applied"] is False
     # diff.changes mirrors the artifact convention — outputs and renders
     # are sub-sections, not top-level fields.
     assert "outputs" in parsed["changes"]

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -981,10 +981,18 @@ def test_run_no_preview_second_run_still_writes_diff(runner, isolated_dir):
     parsed = json.loads(result.stdout)
     assert "diff" in parsed
     assert parsed["diff"]["against"] == "first"
-    assert parsed["diff"]["comparison"]["method"] == "four_view_image_mask"
-    assert "visual_overlap" in parsed["diff"]["comparison"]
+    projection = parsed["diff"]["projection_comparison"]
+    assert projection["method"] == "four_view_image_mask"
+    assert "score" in projection
+    assert (
+        parsed["diff"]["comparison_3d"]["method"]
+        == "source_frame_boolean_volume"
+    )
+    assert parsed["diff"]["comparison_3d"]["volumes"]["shared"] == 1000.0
     assert (isolated_dir / "v2_second" / "diff_side.png").exists()
     assert (isolated_dir / "v2_second" / "diff_overlay.png").exists()
+    assert (isolated_dir / "v2_second" / "diff_volume.png").exists()
+    assert (isolated_dir / "v2_second" / "diff_volume.glb").exists()
 
 
 def test_run_no_preview_second_run_viewer_includes_prior(runner, isolated_dir):
@@ -1085,10 +1093,15 @@ def test_run_auto_diff_png_when_prior_success(runner, isolated_dir):
     assert p2["diff"]["against"] == "first"
     assert p2["diff"]["side_by_side"] == "v2_second/diff_side.png"
     assert p2["diff"]["overlay"] == "v2_second/diff_overlay.png"
-    assert p2["diff"]["comparison"]["alignment"]["mode"] == "bounding_box_center"
-    assert len(p2["diff"]["comparison"]["views"]) == 4
+    projection = p2["diff"]["projection_comparison"]
+    assert projection["alignment"]["mode"] == "bounding_box_center"
+    assert len(projection["views"]) == 4
+    assert p2["diff"]["comparison_3d"]["alignment"]["mode"] == "source_frame"
+    assert p2["diff"]["volume_png"] == "v2_second/diff_volume.png"
+    assert p2["diff"]["volume_glb"] == "v2_second/diff_volume.glb"
     assert (isolated_dir / "v2_second" / "diff_side.png").exists()
     assert (isolated_dir / "v2_second" / "diff_overlay.png").exists()
+    assert (isolated_dir / "v2_second" / "diff_volume.png").exists()
 
 
 def test_run_auto_diff_skips_failed_versions(runner, isolated_dir):

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -1057,9 +1057,9 @@ def test_run_preview_is_4view_composite_1024(runner, isolated_dir):
     png = isolated_dir / "v1_label" / "preview.png"
     data = png.read_bytes()
     width, height = struct.unpack(">II", data[16:24])
-    # 2 panels wide × 512px = 1024, plus label bars stacked (2 × (512 + 22) = 1068)
+    # 2 panels wide x 512px, plus two 30px label bars.
     assert width == 1024
-    assert height == 1068
+    assert height == 1084
 
 
 def test_run_auto_diff_png_when_prior_success(runner, isolated_dir):
@@ -1818,7 +1818,7 @@ def test_run_viewer_parts_panel_includes_named_parts(runner, isolated_dir):
     assert "partMatchesNameExact" in viewer_html
     assert "Longest IDs first avoids" in viewer_html
     assert "&& !partState.ghostRest" in viewer_html
-    assert "attach(sceneA_split, MODEL_A_URL, {})" in viewer_html
+    assert "attach(sceneA_split, MODEL_A_URL, { alignToCenter: true })" in viewer_html
 
     from PIL import Image
     preview_img = Image.open(isolated_dir / "v1" / "preview.png").convert("RGB")

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -981,6 +981,8 @@ def test_run_no_preview_second_run_still_writes_diff(runner, isolated_dir):
     parsed = json.loads(result.stdout)
     assert "diff" in parsed
     assert parsed["diff"]["against"] == "first"
+    assert parsed["diff"]["comparison"]["method"] == "four_view_image_mask"
+    assert "visual_overlap" in parsed["diff"]["comparison"]
     assert (isolated_dir / "v2_second" / "diff_side.png").exists()
     assert (isolated_dir / "v2_second" / "diff_overlay.png").exists()
 
@@ -1083,6 +1085,8 @@ def test_run_auto_diff_png_when_prior_success(runner, isolated_dir):
     assert p2["diff"]["against"] == "first"
     assert p2["diff"]["side_by_side"] == "v2_second/diff_side.png"
     assert p2["diff"]["overlay"] == "v2_second/diff_overlay.png"
+    assert p2["diff"]["comparison"]["alignment"]["mode"] == "bounding_box_center"
+    assert len(p2["diff"]["comparison"]["views"]) == 4
     assert (isolated_dir / "v2_second" / "diff_side.png").exists()
     assert (isolated_dir / "v2_second" / "diff_overlay.png").exists()
 

--- a/tests/test_solid_compare.py
+++ b/tests/test_solid_compare.py
@@ -1,0 +1,109 @@
+import cadquery as cq
+import pytest
+from PIL import Image
+
+from agentcad.solid_compare import (
+    compare_solid_volumes,
+    write_solid_comparison_artifacts,
+)
+
+
+def _box(size=10, translation=(0, 0, 0)):
+    return (
+        cq.Workplane("XY")
+        .box(size, size, size)
+        .translate(translation)
+        .val()
+        .wrapped
+    )
+
+
+def test_identical_solids_have_complete_shared_volume():
+    comparison = compare_solid_volumes(_box(), _box())
+
+    assert comparison.available
+    assert comparison.data["classification"] == "same_occupied_volume"
+    assert comparison.data["volumes"] == {
+        "reference": 1000.0,
+        "candidate": 1000.0,
+        "shared": 1000.0,
+        "reference_only": 0.0,
+        "candidate_only": 0.0,
+        "union": 1000.0,
+    }
+    assert comparison.data["ratios"] == {
+        "volume_iou": 1.0,
+        "reference_coverage": 1.0,
+        "candidate_coverage": 1.0,
+    }
+
+
+def test_partially_overlapping_solids_report_directional_volumes():
+    comparison = compare_solid_volumes(_box(), _box(translation=(5, 0, 0)))
+
+    assert comparison.data["classification"] == "partial_shared_volume"
+    assert comparison.data["volumes"]["shared"] == pytest.approx(500.0)
+    assert comparison.data["volumes"]["reference_only"] == pytest.approx(500.0)
+    assert comparison.data["volumes"]["candidate_only"] == pytest.approx(500.0)
+    assert comparison.data["ratios"]["volume_iou"] == pytest.approx(0.3333)
+    assert comparison.data["ratios"]["reference_coverage"] == pytest.approx(0.5)
+    assert comparison.data["ratios"]["candidate_coverage"] == pytest.approx(0.5)
+
+
+def test_source_frame_does_not_align_identical_translated_solids():
+    comparison = compare_solid_volumes(
+        _box(),
+        _box(translation=(100, 0, 0)),
+    )
+
+    assert comparison.data["classification"] == "no_shared_volume"
+    assert comparison.data["volumes"]["shared"] == 0.0
+    assert comparison.data["ratios"]["volume_iou"] == 0.0
+    assert comparison.data["alignment"] == {
+        "mode": "source_frame",
+        "transform_applied": False,
+    }
+
+
+def test_surface_without_closed_solid_is_unavailable():
+    face = cq.Workplane("XY").rect(10, 10).val().wrapped
+
+    comparison = compare_solid_volumes(face, _box())
+
+    assert not comparison.available
+    assert comparison.data["status"] == "unavailable"
+    assert comparison.data["reason"]["code"] == "reference_has_no_closed_solid"
+
+
+def test_boolean_failure_is_structured(monkeypatch):
+    def fail(*_args, **_kwargs):
+        raise RuntimeError("synthetic failure")
+
+    monkeypatch.setattr("agentcad.solid_compare._run_boolean", fail)
+
+    comparison = compare_solid_volumes(_box(), _box())
+
+    assert not comparison.available
+    assert comparison.data["reason"]["code"] == "boolean_operation_failed"
+    assert "synthetic failure" in comparison.data["reason"]["message"]
+
+
+def test_successful_comparison_writes_colored_glb_and_png(tmp_path):
+    comparison = compare_solid_volumes(
+        _box(),
+        _box(translation=(5, 0, 0)),
+    )
+    glb_path = tmp_path / "diff_volume.glb"
+    png_path = tmp_path / "diff_volume.png"
+
+    written = write_solid_comparison_artifacts(
+        comparison,
+        glb_path,
+        png_path,
+    )
+
+    assert written
+    assert glb_path.exists()
+    assert glb_path.stat().st_size > 0
+    with Image.open(png_path) as image:
+        assert image.size == (1024, 1216)

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -166,6 +166,9 @@ def test_view_two_files_side_by_side_markers(runner, isolated_dir, monkeypatch):
     # Both model labels should appear in the UI
     assert "a.glb" in html
     assert "b.glb" in html
+    # Two-model scenes normalize unrelated source origins into one comparison frame.
+    assert "alignToCenter: true" in html
+    assert "model.position.sub(sourceCenter)" in html
 
 
 def test_view_two_files_step_auto_converts(runner, isolated_dir, monkeypatch):
@@ -184,13 +187,19 @@ def test_view_two_files_step_auto_converts(runner, isolated_dir, monkeypatch):
     # Both GLBs get written alongside the STEPs
     assert (isolated_dir / "a.glb").exists()
     assert (isolated_dir / "b.glb").exists()
-    # Agent-facing PNG — the composite an agent can actually look at
+    # Agent-facing PNGs: four matched A/B views plus four aligned overlays.
     assert "png" in parsed
     png_path = Path(parsed["png"])
     assert png_path.exists()
     assert png_path.stat().st_size > 0
+    assert "overlay_png" in parsed
+    overlay_png_path = Path(parsed["overlay_png"])
+    assert overlay_png_path.exists()
+    assert overlay_png_path.stat().st_size > 0
     html = (isolated_dir / "diff_a_b.html").read_text()
-    assert "data:image/png;base64," in html
+    assert html.count("data:image/png;base64,") == 2
+    assert "four matched views" in html
+    assert "four center-aligned overlays" in html
 
 
 def test_view_two_glbs_no_png(runner, isolated_dir, monkeypatch):
@@ -436,6 +445,10 @@ def test_diff_visual_flag_produces_diff_html_and_png(runner, isolated_dir, monke
     png_path = isolated_dir / parsed["visual"]["png"]
     assert png_path.exists()
     assert png_path.stat().st_size > 0
+    assert "overlay_png" in parsed["visual"]
+    overlay_png_path = isolated_dir / parsed["visual"]["overlay_png"]
+    assert overlay_png_path.exists()
+    assert overlay_png_path.stat().st_size > 0
 
 
 def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
@@ -447,8 +460,11 @@ def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
     assert result.exit_code == 0
     parsed = json.loads(result.stdout)
     assert parsed["visual"]["mode"] == "overlay"
+    assert "png" in parsed["visual"]
+    assert "overlay_png" in parsed["visual"]
     html = (isolated_dir / parsed["visual"]["html"]).read_text()
     assert 'id="opacity-a"' in html
+    assert html.count("data:image/png;base64,") == 2
 
 
 def test_diff_without_visual_unchanged(runner, isolated_dir):

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -189,6 +189,8 @@ def test_view_two_files_step_auto_converts(runner, isolated_dir, monkeypatch):
     png_path = Path(parsed["png"])
     assert png_path.exists()
     assert png_path.stat().st_size > 0
+    html = (isolated_dir / "diff_a_b.html").read_text()
+    assert "data:image/png;base64," in html
 
 
 def test_view_two_glbs_no_png(runner, isolated_dir, monkeypatch):
@@ -427,6 +429,7 @@ def test_diff_visual_flag_produces_diff_html_and_png(runner, isolated_dir, monke
     assert html_path.exists()
     html = html_path.read_text()
     assert html.count("data:application/octet-stream;base64,") == 2
+    assert "data:image/png;base64," in html
 
     # Agent-facing PNG — the whole point of this feature
     assert "png" in parsed["visual"]

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -196,10 +196,13 @@ def test_view_two_files_step_auto_converts(runner, isolated_dir, monkeypatch):
     overlay_png_path = Path(parsed["overlay_png"])
     assert overlay_png_path.exists()
     assert overlay_png_path.stat().st_size > 0
+    assert parsed["comparison"]["method"] == "four_view_image_mask"
+    assert parsed["comparison"]["alignment"]["mode"] == "bounding_box_center"
+    assert len(parsed["comparison"]["views"]) == 4
     html = (isolated_dir / "diff_a_b.html").read_text()
     assert html.count("data:image/png;base64,") == 2
     assert "four matched views" in html
-    assert "four center-aligned overlays" in html
+    assert "semantic difference map" in html
 
 
 def test_view_two_glbs_no_png(runner, isolated_dir, monkeypatch):
@@ -449,6 +452,8 @@ def test_diff_visual_flag_produces_diff_html_and_png(runner, isolated_dir, monke
     overlay_png_path = isolated_dir / parsed["visual"]["overlay_png"]
     assert overlay_png_path.exists()
     assert overlay_png_path.stat().st_size > 0
+    assert parsed["visual"]["comparison"]["method"] == "four_view_image_mask"
+    assert "visual_overlap" in parsed["visual"]["comparison"]
 
 
 def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
@@ -462,6 +467,7 @@ def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
     assert parsed["visual"]["mode"] == "overlay"
     assert "png" in parsed["visual"]
     assert "overlay_png" in parsed["visual"]
+    assert parsed["visual"]["comparison"]["alignment"]["relative_scale"] == "preserved"
     html = (isolated_dir / parsed["visual"]["html"]).read_text()
     assert 'id="opacity-a"' in html
     assert html.count("data:image/png;base64,") == 2

--- a/tests/test_view.py
+++ b/tests/test_view.py
@@ -196,13 +196,19 @@ def test_view_two_files_step_auto_converts(runner, isolated_dir, monkeypatch):
     overlay_png_path = Path(parsed["overlay_png"])
     assert overlay_png_path.exists()
     assert overlay_png_path.stat().st_size > 0
-    assert parsed["comparison"]["method"] == "four_view_image_mask"
-    assert parsed["comparison"]["alignment"]["mode"] == "bounding_box_center"
-    assert len(parsed["comparison"]["views"]) == 4
+    projection = parsed["projection_comparison"]
+    assert projection["method"] == "four_view_image_mask"
+    assert projection["alignment"]["mode"] == "bounding_box_center"
+    assert len(projection["views"]) == 4
+    assert parsed["comparison_3d"]["method"] == "source_frame_boolean_volume"
+    assert parsed["comparison_3d"]["volumes"]["shared"] == 1000.0
+    assert Path(parsed["volume_glb"]).exists()
+    assert Path(parsed["volume_png"]).exists()
     html = (isolated_dir / "diff_a_b.html").read_text()
-    assert html.count("data:image/png;base64,") == 2
+    assert html.count("data:image/png;base64,") == 3
     assert "four matched views" in html
-    assert "semantic difference map" in html
+    assert "centered 2D projection map" in html
+    assert "source-frame 3D volume" in html
 
 
 def test_view_two_glbs_no_png(runner, isolated_dir, monkeypatch):
@@ -452,8 +458,9 @@ def test_diff_visual_flag_produces_diff_html_and_png(runner, isolated_dir, monke
     overlay_png_path = isolated_dir / parsed["visual"]["overlay_png"]
     assert overlay_png_path.exists()
     assert overlay_png_path.stat().st_size > 0
-    assert parsed["visual"]["comparison"]["method"] == "four_view_image_mask"
-    assert "visual_overlap" in parsed["visual"]["comparison"]
+    projection = parsed["visual"]["projection_comparison"]
+    assert projection["method"] == "four_view_image_mask"
+    assert "score" in projection
 
 
 def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
@@ -467,10 +474,16 @@ def test_diff_visual_with_overlay(runner, isolated_dir, monkeypatch):
     assert parsed["visual"]["mode"] == "overlay"
     assert "png" in parsed["visual"]
     assert "overlay_png" in parsed["visual"]
-    assert parsed["visual"]["comparison"]["alignment"]["relative_scale"] == "preserved"
+    assert (
+        parsed["visual"]["projection_comparison"]["alignment"]["relative_scale"]
+        == "preserved"
+    )
+    assert parsed["comparison_3d"]["alignment"]["mode"] == "source_frame"
+    assert "volume_glb" in parsed["visual"]
+    assert "volume_png" in parsed["visual"]
     html = (isolated_dir / parsed["visual"]["html"]).read_text()
     assert 'id="opacity-a"' in html
-    assert html.count("data:image/png;base64,") == 2
+    assert html.count("data:image/png;base64,") == 3
 
 
 def test_diff_without_visual_unchanged(runner, isolated_dir):

--- a/tests_b3d/test_run_end_to_end.py
+++ b/tests_b3d/test_run_end_to_end.py
@@ -280,9 +280,9 @@ class TestPreview:
         png = isolated_dir / "v1_label" / "preview.png"
         data = png.read_bytes()
         width, height = _struct.unpack(">II", data[16:24])
-        # 2 panels wide × 512px = 1024, plus label bars stacked (2 × (512+22) = 1068).
+        # 2 panels wide x 512px, plus two 30px label bars.
         assert width == 1024
-        assert height == 1068
+        assert height == 1084
 
     def test_default_does_not_auto_render_preview_gif(self, runner, isolated_dir):
         """Turntable GIFs are on-demand via the viewer's Export GIF button —


### PR DESCRIPTION
## Summary

- allow `agentcad diff` to compare standalone STEP/STP/BREP file paths before requiring an AgentCAD manifest
- compute metric deltas directly from loaded CAD shapes for file-pair diffs
- center two-model browser scenes into a shared comparison frame while preserving relative size
- give Agent view four matched A/B views and an explicitly 2D centered projection map
- label coincident, reference-only, and candidate-only projected pixels without implying shared 3D geometry
- return a defined projection-IoU score, aggregation method, alignment, limitations, and per-view fractions of union
- calculate actual shared, reference-only, and candidate-only 3D volumes with source-frame OpenCascade Boolean operations
- report volume IoU plus directional reference/candidate coverage with millimeter units and explicit no-alignment metadata
- write matte gray/blue/orange `diff_volume.png` and `diff_volume.glb` artifacts for successful closed-solid comparisons
- return structured `unavailable` results for open, invalid, or failed solid comparisons without failing the normal diff
- include projection and 3D volume comparisons in explicit diff/view commands and automatic run/import edit flows
- constrain the optional MCP SDK dependency to the compatible 1.x API

Closes #106.

## Testing

- `uv run --extra dev --extra mcp pytest`
- 1,180 passed, 3 skipped
- focused comparison/workflow suite: 343 passed
- manually inspected the pump-manifold/CADGenBench projection and source-frame volume artifacts plus structured responses
- verified that the fixture reports zero shared 3D volume because its source-coordinate Z ranges are disjoint
