### PR TITLE
ci: run the docs/help contamination guards in smoke

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -24,8 +24,12 @@ jobs:
       - name: Collect tests
         run: pytest --collect-only -q
 
-      - name: Run OCP-free interface guardrails
-        run: pytest tests/test_help_consistency.py tests/test_package_positioning.py -q
+      - name: Run interface guardrails
+        # test_docs.py / test_help.py carry the #117 + #120 contamination guards:
+        # no CadQuery code in the default build123d docs, no build123d code in
+        # the compat docs. They only exercise CLI text, so they belong here
+        # rather than in the full OCP suite.
+        run: pytest tests/test_help_consistency.py tests/test_package_positioning.py tests/test_docs.py tests/test_help.py -q
 
   windows-platform:
     runs-on: windows-latest


### PR DESCRIPTION
Closes #125.

Appends `tests/test_docs.py` and `tests/test_help.py` to the guardrail step at `smoke.yml:28`, so the #117/#120 contamination guards actually run on a pull request.

## One correction to the issue

The issue says "Verified `agentcad.cli` imports clean without OCP". It does not:

```
src/agentcad/cli.py:12
  -> src/agentcad/commands/diff.py:12
    -> src/agentcad/metrics.py:3   from OCP.Bnd import Bnd_Box
ModuleNotFoundError: No module named 'OCP'
```

That does not change the conclusion — `cadquery>=2.0` and `build123d` are **main** dependencies, so `pip install -e .[mcp,dev]` brings OCP in and these tests run in that job exactly as the issue expects. But it does mean the step name was already inaccurate: `test_help_consistency.py`, which the step *already* runs, imports `agentcad.cli` too, so the step has never been OCP-free.

So I renamed it `Run interface guardrails` rather than leaving a label asserting a property the step does not have. Happy to revert the rename if you'd rather keep the diff to one line.

## Verification

All four files together, against `main`:

```
96 passed
```

And the acceptance criterion — planting `cq.Workplane` into `SECTIONS["install"]`:

```
E  AssertionError: default docs teach 'cq.Workplane'
E  assert 'cq.Workplane' not in '  result = ...123d mode.\n'
E    'cq.Workplane' is contained here:
E        result = cq.Workplane('XY').box(1, 1, 1)
```

The step fails with a pytest assertion naming the leaked token, which is what the issue asks for.

I have no OCP locally, so I ran these by stubbing the OCP *import surface* only (a module whose attributes raise if anything actually calls into geometry). These four files never touch geometry — they invoke `agentcad docs` / `--help` through `CliRunner` and scan the output for tokens — so the stub only satisfies the import chain. Any test that reached real geometry would have raised loudly rather than passed quietly.
