### PR TITLE
Run documentation contamination guards in smoke CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -25,7 +25,7 @@ jobs:
         run: pytest --collect-only -q
 
       - name: Run OCP-free interface guardrails
-        run: pytest tests/test_help_consistency.py tests/test_package_positioning.py -q
+        run: pytest tests/test_help_consistency.py tests/test_package_positioning.py tests/test_docs.py tests/test_help.py -q
 
   windows-platform:
     runs-on: windows-latest


### PR DESCRIPTION
## Summary

- run the existing documentation contamination guards in the pull-request smoke workflow
- include both `tests/test_docs.py` and `tests/test_help.py` in the interface guardrail step

## Testing

- `uv run --python 3.12 --extra mcp --extra dev pytest tests/test_help_consistency.py tests/test_package_positioning.py tests/test_docs.py tests/test_help.py -q` (96 passed)
- `git diff --check`

Closes #125