### PR TITLE
Fix imported STEP volume and reported tool version

### DIFF
--- a/src/agentcad/commands/context.py
+++ b/src/agentcad/commands/context.py
@@ -2,9 +2,8 @@ import json
 
 import click
 
+from agentcad import __version__
 from agentcad.manifest import load_manifest
-
-TOOL_VERSION = "0.1.0"
 
 
 @click.command()
@@ -32,7 +31,7 @@ def context():
         "command": "context",
         "status": "success",
         "project": manifest["name"],
-        "tool_version": TOOL_VERSION,
+        "tool_version": __version__,
         "current": current,
         "version_count": len(versions),
         "versions": versions_summary,

--- a/src/agentcad/commands/import_cmd.py
+++ b/src/agentcad/commands/import_cmd.py
@@ -15,8 +15,8 @@ from pathlib import Path
 
 import click
 
+from agentcad import __version__
 from agentcad import file_detect
-from agentcad.commands.context import TOOL_VERSION
 from agentcad.commands._daemon_routing import (
     maybe_route_through_daemon,
     maybe_spawn_daemon_for_next_run,
@@ -314,7 +314,7 @@ def import_cmd(file, label, init_flag, open_view, runtime, no_daemon):
         "source": "import",
         "original_filename": file_path.name,
         "sha256": sha256,
-        "tool_version": TOOL_VERSION,
+        "tool_version": __version__,
         "created": datetime.now(timezone.utc).isoformat(),
         "outputs": outputs,
         "preview": f"{dir_name}/preview.png",

--- a/src/agentcad/runners/build123d.py
+++ b/src/agentcad/runners/build123d.py
@@ -390,16 +390,20 @@ def _load_step(path: str):
     silencing OCCT's native stdout writes (which would otherwise leak
     into the script's output and break JSON contracts).
     """
-    from build123d import Part, import_step
+    from build123d import Compound, Part, import_step
     from agentcad.native_io import silence_native_stdout
 
     with silence_native_stdout():
         loaded = import_step(path)
-    # `import_step` returns a Compound; wrap in Part for the documented
-    # `load_step(path) -> Part` contract. Part accepts a Compound.
+    # A single-solid STEP imports as a Solid. Passing its raw TopoDS_Solid
+    # directly to Part creates a wrapper whose own volume is zero even though
+    # its child solid is valid. Give Part a real compound so its aggregate
+    # properties include the imported geometry.
     if isinstance(loaded, Part):
         return loaded
-    return Part(loaded.wrapped) if hasattr(loaded, "wrapped") else Part(loaded)
+    if isinstance(loaded, Compound):
+        return Part(loaded.wrapped)
+    return Part(Compound(children=[loaded]).wrapped)
 
 
 def _load_step_shape(path: str):

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -1,6 +1,7 @@
 import json
 
 from click.testing import CliRunner
+from agentcad import __version__
 from agentcad.cli import cli
 
 
@@ -82,4 +83,4 @@ def test_context_includes_tool_version(runner, isolated_dir):
     result = runner.invoke(cli, ["context"])
     data = json.loads(result.stdout)
     assert "tool_version" in data
-    assert data["tool_version"] == "0.1.0"
+    assert data["tool_version"] == __version__

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -13,6 +13,7 @@ import cadquery as cq
 import pytest
 from cadquery import exporters
 
+from agentcad import __version__
 from agentcad.cli import cli
 
 
@@ -99,7 +100,7 @@ class TestImportCore:
         assert meta["source"] == "import"
         assert meta["original_filename"] == "bracket.step"
         assert meta["sha256"] == original_sha
-        assert "tool_version" in meta
+        assert meta["tool_version"] == __version__
 
     def test_manifest_entry_marks_source_as_import(self, runner, isolated_dir):
         _init_project(runner, isolated_dir)

--- a/tests_b3d/test_runner.py
+++ b/tests_b3d/test_runner.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from agentcad.metrics import compute_metrics
 from agentcad.runners import build123d as b3d_runner
 from agentcad.runners.build123d import discover_parameters
@@ -125,6 +127,40 @@ def test_step_export_accepts_build123d_shape(tmp_path):
     out = tmp_path / "out.step"
     export_step(result.native_shape, str(out))
     assert out.exists() and out.stat().st_size > 0
+
+
+def test_load_step_preserves_single_solid_volume(tmp_path):
+    """A STEP containing one solid must remain a real, measurable Part."""
+    from build123d import Box, Part, export_step
+
+    source = tmp_path / "box.step"
+    export_step(Box(10, 10, 10), str(source))
+
+    loaded = b3d_runner._load_step(str(source))
+
+    assert isinstance(loaded, Part)
+    assert len(loaded.solids()) == 1
+    assert loaded.volume == pytest.approx(1000.0)
+    assert loaded.volume == pytest.approx(loaded.solids()[0].volume)
+
+
+def test_load_step_preserves_multi_solid_volume(tmp_path):
+    """Normalizing a single Solid must not break compound STEP files."""
+    from build123d import Box, Compound, Part, Pos, export_step
+
+    source = tmp_path / "two-boxes.step"
+    shape = Compound(children=[
+        Box(1, 2, 3),
+        Pos(10, 0, 0) * Box(2, 3, 4),
+    ])
+    export_step(shape, str(source))
+
+    loaded = b3d_runner._load_step(str(source))
+
+    assert isinstance(loaded, Part)
+    assert len(loaded.solids()) == 2
+    assert loaded.volume == pytest.approx(30.0)
+    assert loaded.volume == pytest.approx(sum(s.volume for s in loaded.solids()))
 
 
 _RAW_TOPODS_COMPOUND_SCRIPT = """\


### PR DESCRIPTION
## Summary

- Preserve measurable aggregate volume when `load_step()` imports a single-solid STEP file.
- Keep multi-solid STEP imports working while retaining the documented `Part` return type.
- Report the installed AgentCAD package version in context output and import metadata instead of the stale hardcoded `0.1.0` value.
- Add regression coverage using real exported STEP files.

## Issue Link

- No issue; standalone bugs found during use

## Validation

- [x] I ran the smallest meaningful test or manual repro.
- [x] `pytest -q tests_b3d/test_runner.py tests/test_context.py tests/test_import.py` — 62 passed.
- [x] Single-solid STEP: one solid with aggregate volume 1000.
- [x] Multi-solid STEP: two solids with aggregate volume equal to the sum of both solids.
- [x] `git diff --check`.
