### PR TITLE
Release v0.4.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.4.0"
+version = "0.4.1"
 description = "CLI CAD tool for AI agents. Write build123d scripts, with CadQuery compatibility, and get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
## Summary

- bump the package from 0.4.0 to 0.4.1
- publish the build123d-primary interface and imported-STEP editing guidance already merged on main
- publish the rebuilt comparison pipeline: safe core commits, recovery, observable/bounded phases, hardened exact comparison, and labeled approximate fallback

## Validation

- `pytest` — 1333 passed, 3 skipped
- `python -m build` — wheel and sdist built successfully with version 0.4.1 metadata
- main smoke CI is green for macOS browser viewer, Windows platform checks, and pytest collection

## Release framing

v0.4.1 — Reliable 3D comparison
