### PR TITLE
Route existing CAD into the import/edit workflow

### DIFF
--- a/src/agentcad/commands/init.py
+++ b/src/agentcad/commands/init.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -54,9 +55,53 @@ def init(name, runtime, force):
         "project": project_name,
         "runtime": manifest["runtime"],
     }
+    cad_input = _preferred_cad_input(Path.cwd())
+    if cad_input is not None:
+        response["next_actions"] = [
+            f"agentcad import {shlex.quote(cad_input.name)} — adopt the existing "
+            "CAD as a versioned baseline and create edit.py"
+        ]
+        response["more_at"] = "agentcad docs editing"
+    else:
+        response["next_actions"] = [
+            "agentcad docs quickstart — follow the first-script workflow for "
+            "this project",
+            f"agentcad docs preamble — see the names available in "
+            f"{manifest['runtime']} scripts",
+        ]
+        response["more_at"] = "agentcad docs quickstart"
     if force:
         response["overwrote_existing"] = True
     click.echo(json.dumps(response))
+
+
+def _preferred_cad_input(directory: Path) -> Path | None:
+    """Return one deterministic editable CAD file from ``directory``.
+
+    ``init`` intentionally looks only at direct children. Descending into
+    version folders would make a generated ``vN_*/output.step`` look like a
+    new source input. STEP/STP sort ahead of BREP because they are the common
+    interchange path; names break ties so the response is stable.
+    """
+    ranks = {".step": 0, ".stp": 0, ".brep": 1}
+    try:
+        candidates = [
+            path
+            for path in directory.iterdir()
+            if path.is_file() and path.suffix.lower() in ranks
+        ]
+    except OSError:
+        return None
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        key=lambda path: (
+            ranks[path.suffix.lower()],
+            path.name.casefold(),
+            path.name,
+        ),
+    )
 
 
 def _build_manifest(project_name: str, runtime: str | None) -> dict:

--- a/src/agentcad/commands/inspect_cmd.py
+++ b/src/agentcad/commands/inspect_cmd.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 import sys
 from pathlib import Path
 
@@ -252,16 +253,33 @@ def _inspect_tier0(
         }, exit_code=1)
         return
 
+    command_path = shlex.quote(file_path)
+    is_versioned = _is_recorded_version_file(Path(file_path))
     payload.update({
         "format_detected": detection.get("format"),
         "extension": detection.get("extension"),
         "size_bytes": detection.get("size_bytes"),
-        "next_actions": [
-            f"agentcad view {file_path} — open in a browser to inspect or share with humans",
-            f"agentcad measure {file_path} — get dimensions, edge lengths, and hole diameters",
-        ],
-        "more_at": "agentcad docs inspect",
     })
+    if is_versioned:
+        payload.update({
+            "next_actions": [
+                f"agentcad view {command_path} — open in a browser to inspect "
+                "or share with humans",
+                f"agentcad measure {command_path} — get dimensions, edge "
+                "lengths, and hole diameters",
+            ],
+            "more_at": "agentcad docs inspect",
+        })
+    else:
+        payload.update({
+            "next_actions": [
+                f"agentcad import {command_path} — adopt the existing CAD as a "
+                "versioned baseline and create edit.py",
+                f"agentcad inspect {command_path} --ids — get feature IDs for "
+                "targeted edits",
+            ],
+            "more_at": "agentcad docs editing",
+        })
 
     if with_ids or with_summary:
         from agentcad import topo_ids
@@ -290,11 +308,19 @@ def _inspect_tier0(
         # action shifts: they're here because they want to write an edit
         # script that targets specific features. Point them at the
         # import → load_step → pick_face flow.
-        payload["next_actions"] = [
-            f"agentcad import {file_path} — adopt as v1 so you can edit and diff",
-            "use pick_face(base, ID) / pick_edge(base, ID) in your edit script — "
-            "see `agentcad docs editing`",
-        ]
+        if is_versioned:
+            payload["next_actions"] = [
+                "agentcad docs editing — use the returned IDs with "
+                "pick_face/pick_edge in the existing edit script",
+            ]
+        else:
+            payload["next_actions"] = [
+                f"agentcad import {command_path} — adopt the existing CAD as a "
+                "versioned baseline and create edit.py",
+                "agentcad docs editing — use the returned IDs with "
+                "pick_face/pick_edge in edit.py",
+            ]
+        payload["more_at"] = "agentcad docs editing"
         if truncations:
             payload["truncation"] = {
                 "limited": True,
@@ -350,6 +376,39 @@ def _inspect_tier0(
         payload["notes"] = notes
 
     _emit(payload, exit_code=0)
+
+
+def _is_recorded_version_file(file_path: Path) -> bool:
+    """Whether ``file_path`` belongs to a version recorded by this project.
+
+    Manifest history records a version directory rather than every artifact.
+    Treating files beneath that directory as versioned covers normalized STEP
+    outputs and imported source copies without depending on optional metadata.
+    A missing or malformed manifest must not break ``inspect``'s never-throws
+    contract, so uncertain cases remain eligible for import guidance.
+    """
+    from agentcad.manifest import MANIFEST_FILE
+
+    manifest_path = Path.cwd() / MANIFEST_FILE
+    if not manifest_path.is_file():
+        return False
+    try:
+        manifest = json.loads(manifest_path.read_text())
+        if not isinstance(manifest, dict):
+            return False
+        target = file_path.resolve()
+        for version in manifest.get("versions", []):
+            if not isinstance(version, dict):
+                continue
+            recorded_path = version.get("path")
+            if not isinstance(recorded_path, str) or not recorded_path:
+                continue
+            version_dir = (Path.cwd() / recorded_path).resolve()
+            if target == version_dir or version_dir in target.parents:
+                return True
+    except (OSError, ValueError, TypeError, RuntimeError):
+        return False
+    return False
 
 
 def _list_truncations(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,9 @@
 import json
+import shlex
 from datetime import datetime
+
+import cadquery as cq
+from cadquery import exporters
 
 from agentcad import __version__
 from agentcad.cli import cli
@@ -51,6 +55,78 @@ def test_init_success_json_schema(runner, isolated_dir):
     assert parsed["command"] == "init"
     assert parsed["status"] == "success"
     assert "project" in parsed
+
+
+def test_init_without_cad_returns_concise_quickstart_actions(runner, isolated_dir):
+    result = runner.invoke(cli, ["init"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert parsed["next_actions"] == [
+        "agentcad docs quickstart — follow the first-script workflow for this project",
+        "agentcad docs preamble — see the names available in build123d scripts",
+    ]
+    assert parsed["more_at"] == "agentcad docs quickstart"
+
+
+def test_init_with_cad_routes_to_import_scaffold(runner, isolated_dir):
+    (isolated_dir / "input.step").write_text("ISO-10303-21;\n")
+
+    result = runner.invoke(cli, ["init"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert parsed["next_actions"] == [
+        "agentcad import input.step — adopt the existing CAD as a versioned "
+        "baseline and create edit.py"
+    ]
+    assert parsed["more_at"] == "agentcad docs editing"
+
+
+def test_init_cad_choice_prefers_step_then_sorts_by_filename(
+    runner, isolated_dir
+):
+    (isolated_dir / "first.brep").write_text("DBRep_DrawableShape\n")
+    (isolated_dir / "z-last.step").write_text("ISO-10303-21;\n")
+    (isolated_dir / "a first.stp").write_text("ISO-10303-21;\n")
+    version_dir = isolated_dir / "v1_old"
+    version_dir.mkdir()
+    (version_dir / "output.step").write_text("ISO-10303-21;\n")
+
+    result = runner.invoke(cli, ["init"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert parsed["next_actions"][0].startswith(
+        "agentcad import 'a first.stp' —"
+    )
+
+
+def test_init_cad_action_reaches_runnable_import_scaffold(runner, isolated_dir):
+    source = isolated_dir / "input.step"
+    exporters.export(cq.Workplane("XY").box(10, 10, 10), str(source))
+
+    init_result = runner.invoke(cli, ["init"])
+    init_payload = json.loads(init_result.stdout)
+    import_command = init_payload["next_actions"][0].split(" — ", 1)[0]
+
+    import_result = runner.invoke(cli, shlex.split(import_command)[1:])
+    assert import_result.exit_code == 0, import_result.output
+    import_payload = json.loads(import_result.stdout)
+    assert import_payload["scaffold"] == "edit.py"
+    assert (isolated_dir / "edit.py").exists()
+
+    run_result = runner.invoke(
+        cli,
+        [
+            "run", "edit.py", "--output", "unchanged", "--no-preview",
+            "--no-diff", "--no-view", "--no-daemon",
+        ],
+    )
+    assert run_result.exit_code == 0, run_result.output
+    run_payload = json.loads(run_result.stdout)
+    assert run_payload["status"] == "success"
+    assert (isolated_dir / run_payload["outputs"]["step"]).is_file()
 
 
 def test_init_already_initialized_returns_error(runner, isolated_dir):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -69,6 +69,18 @@ def test_init_without_cad_returns_concise_quickstart_actions(runner, isolated_di
     assert parsed["more_at"] == "agentcad docs quickstart"
 
 
+def test_init_quickstart_actions_follow_compatibility_runtime(
+    runner, isolated_dir
+):
+    result = runner.invoke(cli, ["init", "--runtime", "cadquery"])
+
+    assert result.exit_code == 0, result.output
+    parsed = json.loads(result.stdout)
+    assert parsed["next_actions"][1] == (
+        "agentcad docs preamble — see the names available in cadquery scripts"
+    )
+
+
 def test_init_with_cad_routes_to_import_scaffold(runner, isolated_dir):
     (isolated_dir / "input.step").write_text("ISO-10303-21;\n")
 

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -54,6 +54,77 @@ class TestInspectCommand:
         assert parsed["command"] == "inspect"
         assert parsed["status"] == "success"
 
+    def test_unversioned_inspect_routes_to_import_and_feature_ids(
+        self, runner, isolated_dir
+    ):
+        step = _make_step(isolated_dir, "input.step")
+
+        result = runner.invoke(cli, ["inspect", str(step), "--no-daemon"])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        assert len(parsed["next_actions"]) == 2
+        assert parsed["next_actions"][0].startswith("agentcad import ")
+        assert "create edit.py" in parsed["next_actions"][0]
+        assert "agentcad inspect" in parsed["next_actions"][1]
+        assert "--ids" in parsed["next_actions"][1]
+        assert parsed["more_at"] == "agentcad docs editing"
+
+    def test_versioned_inspect_does_not_recommend_reimport(
+        self, runner, isolated_dir
+    ):
+        version_dir = isolated_dir / "v1_baseline"
+        version_dir.mkdir()
+        step = _make_step(version_dir)
+        (isolated_dir / "agentcad.json").write_text(json.dumps({
+            "name": "project",
+            "versions": [{"version": 1, "path": "v1_baseline/"}],
+        }))
+
+        result = runner.invoke(cli, ["inspect", str(step), "--no-daemon"])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        joined = " ".join(parsed["next_actions"])
+        assert "agentcad import" not in joined
+        assert "agentcad view" in joined
+        assert "agentcad measure" in joined
+        assert parsed["more_at"] == "agentcad docs inspect"
+
+    def test_versioned_inspect_ids_does_not_recommend_reimport(
+        self, runner, isolated_dir
+    ):
+        version_dir = isolated_dir / "v1_baseline"
+        version_dir.mkdir()
+        step = _make_step(version_dir)
+        (isolated_dir / "agentcad.json").write_text(json.dumps({
+            "name": "project",
+            "versions": [{"version": 1, "path": "v1_baseline/"}],
+        }))
+
+        result = runner.invoke(
+            cli, ["inspect", str(step), "--ids", "--no-daemon"]
+        )
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        joined = " ".join(parsed["next_actions"])
+        assert "agentcad import" not in joined
+        assert "agentcad docs editing" in joined
+
+    def test_malformed_manifest_does_not_break_inspect_guidance(
+        self, runner, isolated_dir
+    ):
+        step = _make_step(isolated_dir, "input.step")
+        (isolated_dir / "agentcad.json").write_text("[]")
+
+        result = runner.invoke(cli, ["inspect", str(step), "--no-daemon"])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.stdout)
+        assert parsed["status"] == "success"
+        assert parsed["next_actions"][0].startswith("agentcad import ")
+
     def test_inspect_reports_solid_count(self, runner, isolated_dir):
         step = _make_step(isolated_dir)
         result = runner.invoke(cli, ["inspect", str(step)])

--- a/tests/test_inspect_graceful.py
+++ b/tests/test_inspect_graceful.py
@@ -108,7 +108,9 @@ class TestTier0FullEdit:
         assert all(" — " in a for a in parsed["next_actions"])
         assert "more_at" in parsed
 
-    def test_tier0_more_at_points_to_inspect_docs(self, monkeypatch, capsys):
+    def test_unversioned_tier0_more_at_points_to_editing_docs(
+        self, monkeypatch, capsys
+    ):
         import agentcad.commands.inspect_cmd as inspect_module
 
         def fake_topology_report(*args, **kwargs):
@@ -136,7 +138,7 @@ class TestTier0FullEdit:
         )
 
         parsed = json.loads(capsys.readouterr().out)
-        assert parsed["more_at"] == "agentcad docs inspect"
+        assert parsed["more_at"] == "agentcad docs editing"
 
     def test_asymmetric_face_orientations_on_valid_solid_gets_note(
         self, runner, isolated_dir


### PR DESCRIPTION
## Summary

- add contextual `init.next_actions` that route STEP/STP/BREP inputs into the existing `agentcad import` scaffold
- keep direct-generation projects on concise, runtime-aware quickstart guidance
- make `inspect` distinguish unversioned CAD from manifest-recorded version artifacts, avoiding re-import loops
- cover deterministic input selection and the full init → import → unchanged scaffold → STEP journey

## Verification

- `pytest -q` — 1374 passed, 3 skipped
- focused init/inspect suites after final formatting — 37 passed
- CadQuery compatibility quickstart contract — 1 passed
- fresh-agent friction check with the current checkout and `--no-daemon` — passed end to end
- `git diff --check`