### PR TITLE
Use deploy key for skill mirror sync

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -15,40 +15,36 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
-    env:
-      SKILL_SYNC_TOKEN: ${{ secrets.SKILL_SYNC_TOKEN }}
     steps:
-      - name: Skip when mirror token is unavailable
-        if: env.SKILL_SYNC_TOKEN == ''
+      - name: Require mirror deploy key
+        env:
+          SKILL_SYNC_SSH_KEY: ${{ secrets.SKILL_SYNC_SSH_KEY }}
         run: |
-          echo "SKILL_SYNC_TOKEN is not configured; skipping public skill sync."
+          if [ -z "$SKILL_SYNC_SSH_KEY" ]; then
+            echo "SKILL_SYNC_SSH_KEY is not configured."
+            exit 1
+          fi
 
       - uses: actions/checkout@v4
-        if: env.SKILL_SYNC_TOKEN != ''
 
       - uses: actions/setup-python@v5
-        if: env.SKILL_SYNC_TOKEN != ''
         with:
           python-version: "3.12"
 
       - name: Install dependencies
-        if: env.SKILL_SYNC_TOKEN != ''
         run: pip install pyyaml
 
       - name: Generate SKILL.md
-        if: env.SKILL_SYNC_TOKEN != ''
         run: python scripts/generate_skill_md.py > /tmp/SKILL.md
 
       - name: Checkout public skill repo
-        if: env.SKILL_SYNC_TOKEN != ''
         uses: actions/checkout@v4
         with:
           repository: jdilla1277/agentcad-skill
-          token: ${{ env.SKILL_SYNC_TOKEN }}
+          ssh-key: ${{ secrets.SKILL_SYNC_SSH_KEY }}
           path: public-skill
 
       - name: Commit and push if changed
-        if: env.SKILL_SYNC_TOKEN != ''
         working-directory: public-skill
         run: |
           cp /tmp/SKILL.md SKILL.md


### PR DESCRIPTION
## Summary

- replace the expired cross-repository PAT with a repository-scoped deploy key
- fail clearly when the deploy-key secret is missing
- keep public skill generation and push behavior unchanged

## Verification

- dispatched the workflow from this branch successfully: https://github.com/jdilla1277/agentcad/actions/runs/33379641983
- confirmed `jdilla1277/agentcad-skill@main` exactly matches `scripts/generate_skill_md.py` output
- targeted skill tests: 12 passed