### PR TITLE
Bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.4.1"
+version = "0.5.0"
 description = "CLI CAD tool for AI agents. Write build123d scripts, with CadQuery compatibility, and get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"


### PR DESCRIPTION
Agents editing existing CAD now get direct guidance, literal artifact paths, safe failure recovery, and bounded inspection. These changes were merged after 0.4.1 and are ready for public distribution as 0.5.0.

## Summary

- bump the package version from 0.4.1 to 0.5.0
- publish the completed M69 agent-friction improvements
- include the imported-geometry safety, comparison-view, Windows dependency, documentation-surface, and skill-sync fixes merged since the last release

## Validation

- `pytest -q` — 1413 passed, 2 skipped
- `python -m build` — wheel and source archive built successfully with 0.5.0 metadata
- required PR checks are green for pytest collection, Windows platform checks, and the browser viewer