### PR TITLE
Release agentcad 0.5.1

### DIFF
--- a/.github/workflows/sync-skill.yml
+++ b/.github/workflows/sync-skill.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches: [main]
     paths:
+      - "src/agentcad/guide.py"
       - "src/agentcad/commands/skill.py"
       - "pyproject.toml"
       - "scripts/generate_skill_md.py"

--- a/benchmarks/cadgenbench/gpt-5-nano-2026-08/README.md
+++ b/benchmarks/cadgenbench/gpt-5-nano-2026-08/README.md
@@ -8,7 +8,7 @@ fixtures:
 - **Without agentcad:** GPT-5 Nano with a Pi harness and direct build123d
   access.
 - **With agentcad:** the same model and Pi harness with agentcad 0.4.1 and the
-  distributed agentcad skill. Version 0.5.0 makes that skill part of the
+  distributed agentcad skill. Version 0.5.1 makes that skill part of the
   default `agentcad init` experience.
 
 ## Headline results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agentcad"
-version = "0.5.0"
+version = "0.5.1"
 description = "CLI CAD tool for AI agents. Write build123d scripts, with CadQuery compatibility, and get STEP files, renders, and metrics."
 readme = "README.md"
 requires-python = ">=3.10,<3.13"

--- a/scripts/generate_skill_md.py
+++ b/scripts/generate_skill_md.py
@@ -2,7 +2,8 @@
 """Generate SKILL.md for the public jdilla1277/agentcad-skill repo.
 
 Source of truth:
-- Body + base frontmatter: SKILL_CONTENT in src/agentcad/commands/skill.py
+- Body: GUIDE_BODY in src/agentcad/guide.py
+- Base frontmatter: _BUILD123D_FRONTMATTER in src/agentcad/commands/skill.py
 - Version: project.version in pyproject.toml
 
 Adds marketplace-only fields (version, metadata.openclaw) so the result
@@ -12,6 +13,7 @@ Usage: python scripts/generate_skill_md.py > SKILL.md
 """
 from __future__ import annotations
 
+import ast
 import re
 import sys
 import tomllib
@@ -22,24 +24,46 @@ import yaml
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def _read_string_constant(source_path: Path, name: str) -> str:
+    """Read a literal string constant without importing package dependencies."""
+    module = ast.parse(source_path.read_text(), filename=str(source_path))
+    for node in module.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id == name
+            for target in node.targets
+        ):
+            continue
+        value = ast.literal_eval(node.value)
+        if isinstance(value, str):
+            return value
+    raise ValueError(f"{name} not found as a literal string in {source_path}")
+
+
 def main() -> int:
     pyproject = tomllib.loads((ROOT / "pyproject.toml").read_text())
     version = pyproject["project"]["version"]
 
-    skill_py = (ROOT / "src" / "agentcad" / "commands" / "skill.py").read_text()
-    m = re.search(r'SKILL_CONTENT\s*=\s*"""\\?\n?(.*?)"""', skill_py, re.DOTALL)
-    if not m:
-        print("error: SKILL_CONTENT not found in skill.py", file=sys.stderr)
+    try:
+        frontmatter_source = _read_string_constant(
+            ROOT / "src" / "agentcad" / "commands" / "skill.py",
+            "_BUILD123D_FRONTMATTER",
+        )
+        body = _read_string_constant(
+            ROOT / "src" / "agentcad" / "guide.py",
+            "GUIDE_BODY",
+        )
+    except (SyntaxError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
         return 1
-    content = m.group(1)
 
-    fm_match = re.match(r"^---\n(.*?)\n---\n(.*)", content, re.DOTALL)
+    fm_match = re.match(r"^---\n(.*?)\n---\n", frontmatter_source, re.DOTALL)
     if not fm_match:
-        print("error: SKILL_CONTENT has no YAML frontmatter", file=sys.stderr)
+        print("error: _BUILD123D_FRONTMATTER has no YAML frontmatter", file=sys.stderr)
         return 1
 
     frontmatter = yaml.safe_load(fm_match.group(1)) or {}
-    body = fm_match.group(2)
 
     frontmatter["version"] = version
     frontmatter["metadata"] = {

--- a/tests/test_generate_skill_md.py
+++ b/tests/test_generate_skill_md.py
@@ -1,0 +1,31 @@
+"""Regression tests for the public skill-repository generator."""
+
+from pathlib import Path
+import subprocess
+import sys
+import tomllib
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_generate_skill_md_uses_canonical_guide_and_package_version():
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts" / "generate_skill_md.py")],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    _, frontmatter_text, body = result.stdout.split("---\n", maxsplit=2)
+    frontmatter = yaml.safe_load(frontmatter_text)
+    project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+
+    assert frontmatter["name"] == "agentcad"
+    assert frontmatter["version"] == project["version"]
+    assert frontmatter["metadata"]["openclaw"]["requires"]["bins"] == ["agentcad"]
+    assert body.startswith("# agentcad — CAD tool for AI agents\n")
+    assert "## Core workflow" in body


### PR DESCRIPTION
This patch release publishes the agent-ready init experience merged in #162 and repairs the public skill sync regression exposed by that merge.

## Summary

- bump the package version from 0.5.0 to 0.5.1
- publish the new `agentcad init` experience, which installs the canonical agent guide automatically
- update the public skill generator to read the new canonical guide source
- trigger the skill mirror whenever that guide changes
- add a regression test for generated skill content and version metadata
- correct the benchmark evidence note: the run used 0.4.1 plus the distributed skill, while 0.5.1 makes that setup the default

## Validation

- focused init, guide, skill, CLI, and generator tests: 51 passed
- `python -m build`: wheel and source archive built successfully with 0.5.1 metadata
- clean wheel install: package reports 0.5.1 and `agentcad init` creates `.claude/skills/agentcad/SKILL.md` plus `AGENTS.md`
- full test suite is running locally; required PR checks will also run here