### PR TITLE
Clarify benchmark release candidate

### DIFF
--- a/benchmarks/cadgenbench/gpt-5-nano-2026-08/README.md
+++ b/benchmarks/cadgenbench/gpt-5-nano-2026-08/README.md
@@ -7,9 +7,9 @@ fixtures:
 
 - **Without agentcad:** GPT-5 Nano with a Pi harness and direct build123d
   access.
-- **With agentcad:** the same model and Pi harness with agentcad 0.4.1 and the
-  distributed agentcad skill. Version 0.5.1 makes that skill part of the
-  default `agentcad init` experience.
+- **With agentcad:** the same model and Pi harness with the release candidate
+  that became agentcad 0.5.1. It paired the published agentcad 0.4.1 CLI with
+  the distributed agentcad skill.
 
 ## Headline results
 


### PR DESCRIPTION
Readers now get a concise description of the agentcad setup measured by the benchmark. The previous wording separated the tested CLI and the release it became in a way that was harder to parse.

## Summary

- describe the agentcad condition as the release candidate that became 0.5.1
- retain the precise disclosure that it paired the published 0.4.1 CLI with the distributed skill

## Validation

- public evidence verifier passes for both 81-record runs
- token and cost totals remain consistent