### PR TITLE
feat: install the agent guide automatically from agentcad init

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ Install agentcad, then paste this into Claude Code, Cursor, or any coding agent:
 Create a Python 3.12 virtual environment, then:
 
 pip install agentcad
-agentcad skill install
-agentcad instructions install
-agentcad --help
 agentcad init --name phone-stand
+agentcad --help
 
-Read the --help output — it's your guide to creating, checking, and sharing a model.
+init installs the agent operating guide into AGENTS.md and the Claude Code
+skill automatically. Read the --help output — it's your guide to creating,
+checking, and sharing a model.
 Use the default build123d runtime unless the task explicitly requires
 CadQuery compatibility.
 

--- a/src/agentcad/cli.py
+++ b/src/agentcad/cli.py
@@ -242,12 +242,14 @@ COMMAND REFERENCE: PROJECT AND INTEGRATIONS
     and mcp.
 
   agentcad instructions install
-    Record a short project note so future agents read `agentcad --help`.
+    Install or refresh the full agent guide in AGENTS.md/CLAUDE.md so future
+    agents receive it automatically. `agentcad init` runs this by default.
 
   agentcad skill install
   agentcad skill show
-    Install the Claude Code skill in the current project, or return its content
-    as JSON for another agent integration.
+    Install or refresh the Claude Code skill in the current project (also run
+    by `agentcad init` by default), or return its content as JSON for another
+    agent integration.
 
   agentcad feedback "MESSAGE" [--max-entries N] [--local-only]
     Save a diagnostic bundle under .agentcad/feedback and, unless --local-only,

--- a/src/agentcad/commands/context.py
+++ b/src/agentcad/commands/context.py
@@ -4,8 +4,44 @@ from pathlib import Path
 import click
 
 from agentcad import __version__
+from agentcad.commands.instructions import instructions_status
+from agentcad.commands.skill import skill_status
+from agentcad.guide import guide_fingerprint
 from agentcad.manifest import load_manifest
 from agentcad.recovery import recovery_summary
+from agentcad.runners import dispatch
+
+
+def _agent_setup_report(cwd: Path, runtime: str) -> tuple[dict, list[str]]:
+    """Summarize installed agent-guide surfaces and suggest repairs.
+
+    Only advisory: context never mutates instruction files. A stale state is
+    normal right after upgrading agentcad and is fixed by re-running the
+    install commands, which replace only the marked block.
+    """
+    instructions = instructions_status(cwd, runtime)
+    skill = skill_status(cwd, runtime)
+    report = {
+        "guide_fingerprint": guide_fingerprint(runtime),
+        "instructions": instructions,
+        "skill": skill,
+    }
+    actions = []
+    if instructions["state"] != "current":
+        detail = (
+            "install the agent guide into AGENTS.md/CLAUDE.md"
+            if instructions["state"] == "missing"
+            else "refresh the outdated agent guide in AGENTS.md/CLAUDE.md"
+        )
+        actions.append(f"agentcad instructions install — {detail}")
+    if skill["state"] != "current":
+        detail = (
+            "install the Claude Code skill"
+            if skill["state"] == "missing"
+            else "refresh the outdated Claude Code skill"
+        )
+        actions.append(f"agentcad skill install — {detail}")
+    return report, actions
 
 
 @click.command()
@@ -16,6 +52,8 @@ def context():
     versions = manifest.get("versions", [])
     current = manifest.get("current", None)
     recovery = recovery_summary(Path.cwd(), manifest)
+    runtime = manifest.get("runtime") or dispatch.DEFAULT_RUNTIME
+    agent_setup, setup_actions = _agent_setup_report(Path.cwd(), runtime)
 
     versions_summary = [
         {
@@ -30,7 +68,7 @@ def context():
         for v in versions
     ]
 
-    click.echo(json.dumps({
+    response = {
         "command": "context",
         "status": "success",
         "project": manifest["name"],
@@ -39,4 +77,8 @@ def context():
         "version_count": len(versions),
         "versions": versions_summary,
         "recovery": recovery,
-    }))
+        "agent_setup": agent_setup,
+    }
+    if setup_actions:
+        response["next_actions"] = setup_actions
+    click.echo(json.dumps(response))

--- a/src/agentcad/commands/init.py
+++ b/src/agentcad/commands/init.py
@@ -7,8 +7,48 @@ from pathlib import Path
 import click
 
 from agentcad import __version__
+from agentcad.commands.instructions import install_instructions
+from agentcad.commands.skill import install_skill
+from agentcad.guide import guide_fingerprint
 from agentcad.manifest import MANIFEST_FILE
 from agentcad.runners import dispatch
+
+
+def install_agent_setup(cwd: Path, runtime: str) -> dict:
+    """Install every agent-guide surface for a project and report evidence.
+
+    A setup failure must not fail project initialization — the manifest is
+    already written and the CLI remains usable — so errors are reported in
+    the returned status instead of raised.
+    """
+    try:
+        skill_result = install_skill(cwd, runtime)
+        instructions_result = install_instructions(cwd, "auto", runtime)
+    except OSError as exc:
+        return {
+            "status": "error",
+            "message": f"agent guide install failed: {exc}",
+            "suggestion": (
+                "Run `agentcad instructions install` and `agentcad skill "
+                "install` once the underlying issue is fixed."
+            ),
+        }
+    return {
+        "status": "ready",
+        "guide_fingerprint": guide_fingerprint(runtime),
+        "targets": [
+            {
+                "name": "claude-skill",
+                "paths": [skill_result["path"]],
+                "activation": "skill-discovery",
+            },
+            {
+                "name": "project-instructions",
+                "paths": instructions_result["paths"],
+                "activation": "always-loaded",
+            },
+        ],
+    }
 
 
 @click.command()
@@ -29,7 +69,15 @@ from agentcad.runners import dispatch
     "--force", is_flag=True,
     help="Overwrite an existing agentcad.json. Use when re-initializing a project.",
 )
-def init(name, runtime, force):
+@click.option(
+    "--no-agent-setup", is_flag=True,
+    help=(
+        "Skip installing the agent guide (AGENTS.md/CLAUDE.md block and Claude "
+        "skill). By default init installs both so agents receive the operating "
+        "guide automatically."
+    ),
+)
+def init(name, runtime, force, no_agent_setup):
     """Initialize a new agentcad project."""
     manifest_path = Path.cwd() / MANIFEST_FILE
 
@@ -39,8 +87,10 @@ def init(name, runtime, force):
             "status": "error",
             "message": f"{MANIFEST_FILE} already exists",
             "suggestion": (
-                "Pass --force to overwrite, or run `agentcad context` to see "
-                "the current project state."
+                "The project is already initialized. Run `agentcad context` "
+                "to see its state and agent-guide status, or `agentcad "
+                "instructions install` to refresh the agent guide. Pass "
+                "--force only to recreate agentcad.json and start over."
             ),
         }))
         sys.exit(1)
@@ -55,6 +105,12 @@ def init(name, runtime, force):
         "project": project_name,
         "runtime": manifest["runtime"],
     }
+    if no_agent_setup:
+        response["agent_setup"] = {"status": "skipped"}
+    else:
+        response["agent_setup"] = install_agent_setup(
+            Path.cwd(), manifest["runtime"]
+        )
     cad_input = _preferred_cad_input(Path.cwd())
     if cad_input is not None:
         response["next_actions"] = [
@@ -120,8 +176,9 @@ def _build_manifest(project_name: str, runtime: str | None) -> dict:
 def _bootstrap_manifest(name: str | None = None, runtime: str | None = None) -> None:
     """Create a manifest in the current directory. Used by `agentcad import
     --init` so an agent handed a STEP in a fresh folder doesn't have to
-    issue two commands."""
+    issue two commands. Installs the agent guide like `agentcad init` does."""
     manifest_path = Path.cwd() / MANIFEST_FILE
     project_name = name if name else Path.cwd().name
     manifest = _build_manifest(project_name, runtime)
     manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    install_agent_setup(Path.cwd(), manifest["runtime"])

--- a/src/agentcad/commands/instructions.py
+++ b/src/agentcad/commands/instructions.py
@@ -1,26 +1,34 @@
-"""agentcad instructions — install durable project guidance for future agents."""
+"""agentcad instructions — install durable project guidance for future agents.
+
+The installed block is the complete canonical guide from `agentcad.guide`,
+not a pointer to it. AGENTS.md/CLAUDE.md are loaded unconditionally by agent
+harnesses, so this is the one surface that guarantees the guide is in context
+before CAD work starts — skill files and `--help` only work when the agent
+chooses to read them. `agentcad init` installs this block automatically.
+"""
 
 import json
+import re
 from pathlib import Path
 
 import click
 
+from agentcad.guide import effective_runtime, guide_body, guide_fingerprint
+
 
 START_MARKER = "<!-- agentcad:start -->"
 END_MARKER = "<!-- agentcad:end -->"
+_FINGERPRINT_RE = re.compile(r"<!-- agentcad-guide: ([0-9a-f]+) -->")
 
-INSTRUCTIONS_BLOCK = f"""\
-{START_MARKER}
-## agentcad
 
-For CAD/modeling tasks, use `agentcad`. Start by running `agentcad --help`;
-it is the detailed operational briefing and command reference. Use
-`agentcad docs [section]` for deeper examples, write scripts that call
-`show_object(...)`, run with `agentcad run SCRIPT --label LABEL`, inspect the
-generated `preview.png`, and open the result with `agentcad view ...` after
-successful builds.
-{END_MARKER}
-"""
+def instructions_block(runtime: str) -> str:
+    """The AGENTS.md/CLAUDE.md managed block: full guide plus fingerprint."""
+    return (
+        f"{START_MARKER}\n"
+        f"<!-- agentcad-guide: {guide_fingerprint(runtime)} -->\n"
+        f"{guide_body(runtime).rstrip()}\n"
+        f"{END_MARKER}\n"
+    )
 
 
 def _replace_or_append(content: str, block: str) -> str:
@@ -29,7 +37,10 @@ def _replace_or_append(content: str, block: str) -> str:
 
     if start != -1 and end != -1 and start < end:
         end += len(END_MARKER)
-        updated = content[:start].rstrip() + "\n\n" + block.rstrip() + content[end:]
+        prefix = content[:start].rstrip()
+        if prefix:
+            prefix += "\n\n"
+        updated = prefix + block.rstrip() + content[end:]
         return updated.rstrip() + "\n"
 
     if not content.strip():
@@ -53,18 +64,73 @@ def _target_paths(target: str, cwd: Path) -> list[Path]:
     return existing or [agents]
 
 
+def install_instructions(cwd: Path, target: str, runtime: str) -> dict:
+    """Install or refresh the managed block and return install evidence.
+
+    User-authored content outside the markers is always preserved; only the
+    marked block is replaced.
+    """
+    block = instructions_block(runtime)
+    written = []
+    for path in _target_paths(target, cwd):
+        original = path.read_text() if path.exists() else ""
+        path.write_text(_replace_or_append(original, block))
+        written.append(str(path))
+    return {
+        "runtime": runtime,
+        "target": target,
+        "paths": written,
+        "guide_fingerprint": guide_fingerprint(runtime),
+    }
+
+
+def instructions_status(cwd: Path, runtime: str) -> dict:
+    """Report whether any instruction file carries the current guide."""
+    expected = guide_fingerprint(runtime)
+    files = {}
+    for path in (cwd / "AGENTS.md", cwd / "CLAUDE.md"):
+        if not path.exists():
+            continue
+        try:
+            content = path.read_text()
+        except OSError:
+            continue
+        if START_MARKER not in content:
+            continue
+        match = _FINGERPRINT_RE.search(content)
+        installed = match.group(1) if match else None
+        files[path.name] = "current" if installed == expected else "stale"
+
+    if not files:
+        state = "missing"
+    elif "current" in files.values():
+        state = "current"
+    else:
+        state = "stale"
+    return {"state": state, "files": files}
+
+
 @click.group()
 def instructions():
     """Manage project instruction snippets for future agents."""
 
 
 @instructions.command()
-def show():
-    """Print the project instruction snippet as JSON."""
+@click.option(
+    "--runtime",
+    default=None,
+    type=click.Choice(["cadquery", "build123d"]),
+    help="Show the block for an explicit runtime instead of the project mode.",
+)
+def show(runtime):
+    """Print the project instruction block as JSON."""
+    runtime = effective_runtime(runtime)
     click.echo(json.dumps({
         "command": "instructions show",
         "status": "success",
-        "content": INSTRUCTIONS_BLOCK,
+        "runtime": runtime,
+        "guide_fingerprint": guide_fingerprint(runtime),
+        "content": instructions_block(runtime),
     }))
 
 
@@ -79,22 +145,21 @@ def show():
         "or creates AGENTS.md when neither exists."
     ),
 )
-def install(target):
-    """Install the agentcad snippet into AGENTS.md and/or CLAUDE.md."""
-    cwd = Path.cwd()
-    paths = _target_paths(target, cwd)
-    written = []
-
-    for path in paths:
-        original = path.read_text() if path.exists() else ""
-        updated = _replace_or_append(original, INSTRUCTIONS_BLOCK)
-        path.write_text(updated)
-        written.append(str(path))
-
+@click.option(
+    "--runtime",
+    default=None,
+    type=click.Choice(["cadquery", "build123d"]),
+    help="Install the block for an explicit runtime instead of the project mode.",
+)
+def install(target, runtime):
+    """Install the agentcad guide into AGENTS.md and/or CLAUDE.md."""
+    result = install_instructions(Path.cwd(), target, effective_runtime(runtime))
     click.echo(json.dumps({
         "command": "instructions install",
         "status": "success",
-        "target": target,
-        "paths": written,
-        "message": "agentcad instructions installed. Future agents should read agentcad --help for the detailed briefing.",
+        **result,
+        "message": (
+            "agentcad guide installed. Future agents in this project receive it "
+            "automatically from their instruction file."
+        ),
     }))

--- a/src/agentcad/commands/skill.py
+++ b/src/agentcad/commands/skill.py
@@ -1,14 +1,22 @@
-"""agentcad skill — install or show the agent skill file."""
+"""agentcad skill — install or show the agent skill file.
+
+The skill body is the canonical guide from `agentcad.guide`; this module only
+adds the Agent Skills frontmatter and the `.claude/skills` install location.
+`agentcad init` installs the skill automatically, so this command is mainly a
+refresh/repair path.
+"""
 
 import json
 from pathlib import Path
 
 import click
 
-from agentcad.runners import dispatch
+from agentcad.guide import effective_runtime, guide_body, guide_fingerprint
 
 
-SKILL_CONTENT = """\
+SKILL_RELATIVE_PATH = Path(".claude") / "skills" / "agentcad" / "SKILL.md"
+
+_BUILD123D_FRONTMATTER = """\
 ---
 name: agentcad
 description: >
@@ -19,337 +27,52 @@ compatibility: Requires Python 3.10-3.12 and agentcad installed (pip install age
 allowed-tools: Bash(agentcad:*)
 ---
 
-# agentcad — CAD tool for AI agents
-
-You have access to `agentcad`, a CLI that turns build123d Python scripts into 3D
-geometry. All output is JSON. Every command returns `"command"` and `"status"` keys.
-
-## First-time setup
-
-```bash
-agentcad init --name <project_name>
-agentcad --help   # Read the built-in how-to guide and command reference
-```
-
-## Core workflow
-
-1. **Write a script.** No imports needed — build123d primitives,
-   `show_object`, and agentcad edit helpers are pre-injected by default.
-   `show_object(result)` is required.
-
-2. **Dry-run first** to check metrics without consuming a version:
-   ```bash
-   agentcad run script.py --label test --dry-run
-   ```
-   Check `volume`, `dimensions`, `is_valid` in the response.
-
-3. **Run for real.** Visual feedback is on by default:
-   ```bash
-   agentcad run script.py --label label
-   ```
-   A normal successful iteration can produce (paths in the JSON response):
-   - `preview.png` — balanced top, bottom, upper-iso, and lower-iso composite.
-     **Read this** to confirm the part looks right before iterating. The lower
-     views expose geometry that a top view can hide.
-   - `diff.side_by_side` — side-by-side PNG vs the most recent successful prior
-     version, when one exists and automatic diff is enabled. **Read this** when
-     iterating to see what your change did.
-   - `diff.overlay` — centered 2D visual-overlap map (coincident gray,
-     reference-only blue, candidate-only orange). It helps locate silhouette
-     changes but does not prove physical correctness or shared 3D volume.
-   - `viewer.html` — interactive 3D review viewer for the user unless viewer
-     artifacts are disabled (humans only;
-     you can't render HTML). It opens automatically after a successful run.
-     From v2, A=previous and B=current are already loaded with synchronized
-     A/B, side-by-side, overlay, diff-image, and Parts-tab change review.
-
-   Pass `--no-preview` only for tight parametric sweeps where latency matters.
-   Pass `--no-view` only when browser launch would disrupt an unattended or
-   high-volume run.
-
-   For a core-only iteration, pass
-   `--no-preview --no-diff --no-view`. This writes `output.step`, the saved
-   script, `meta.json` (including metrics), and explicitly requested exports
-   without generating previews, automatic comparisons, viewer assets, or
-   opening a browser. You can still run an explicit
-   `agentcad diff OLD NEW` later.
-
-   When a comparison is slow or incomplete, read `comparison_phases` in the
-   JSON response. `source_loading`, `comparison_rendering`,
-   `projection_comparison`, `exact_3d_comparison`,
-   `approximate_3d_comparison`, `difference_artifact_export`, and
-   `viewer_generation` each report a status
-   and, when attempted, `duration_ms`. The largest duration identifies the
-   expensive stage; a failed exact phase does not erase a successful projection.
-   Exact 3D work has a 30-second default worker budget. Set
-   `AGENTCAD_DIFF_TIMEOUT_S=N` to override it (`0` disables the dedicated limit
-   for diagnostics). A timeout leaves the core version and projection usable,
-   then runs a bounded voxel fallback. Approximate results report
-   `method=approximate_voxel_volume`, `resolution_mm`, and a non-strict
-   `error_estimate`; its `absolute_volume` values are heuristic errors, not
-   measurements. `exact_attempt` retains the exact failure. Use
-   `AGENTCAD_APPROX_DIFF_TIMEOUT_S` and `AGENTCAD_APPROX_RESOLUTION_MM` to tune
-   the fallback. If exact volumes are still needed, run
-   `agentcad diff OLD NEW` with a larger budget; do not rerun the original CAD
-   command and create a duplicate version.
-
-   Daemon-routed commands may run beyond 30 seconds. Progress heartbeats appear
-   on stderr while stdout stays reserved for the final JSON response, and the
-   submitted command is never automatically retried. If a silent or lost daemon
-   returns `outcome: "unknown"` and `retry_safe: false`, inspect `agentcad
-   context`, existing outputs, and `agentcad daemon status` before retrying; the
-   original command may already have completed.
-
-4. **Review with the user.** The generated viewer opens automatically. On v2+
-   start with its previous/current comparison, then use A/B, Overlay, and Parts
-   without selecting files manually. Use `agentcad view old.step new.step` only
-   for an explicit non-adjacent comparison.
-
-5. **Inspect if invalid.** If `is_valid: false` or geometry looks wrong:
-   ```bash
-   agentcad inspect v1_label/output.step
-   ```
-
-6. **Measure feature sizes.** For dimensions beyond top-level metrics:
-   ```bash
-   agentcad measure v1_label/output.step
-   ```
-   Use this for hole diameters, cylindrical boss diameters, edge lengths,
-   face areas, and full per-feature measurements with `--features`.
-
-7. **Check explicit feature requirements.** If the prompt names measurable
-   holes, bores, or cylindrical bosses, write them into `spec.json` before
-   final handoff:
-   ```json
-   {"features":[{"name":"bolt_holes","type":"cylinder","diameter_mm":6,"count":4}]}
-   ```
-   Then run:
-   ```bash
-   agentcad check-spec v1_label/output.step spec.json
-   ```
-   Revise the CAD if `passed` is false. `status: success` only means the
-   comparison ran; `passed` is the actual spec-check result. If you include
-   `axis`, copy it from `agentcad measure`'s `cylindrical_features[].axis`.
-
-8. **Iterate.** Fix the script, run with a new `--label` value. Use
-   `agentcad diff 1 2` to compare versions.
-
-## Script writing rules
-
-- `show_object(result)` is required — at least one call.
-- These are pre-injected by default (no import needed):
-  build123d primitives like `Box`, `Cylinder`, `Sphere`, `Plane`, plus
-  `show_object`, `load_step`, `pick_face`, `pick_edge`, `fillet_edges`,
-  `chamfer_edges`, `shell_faces`, `cut_pocket`, `boss`, `split_by_plane`,
-  `replace_face`, `copy_shape`, `safe_cut`, `safe_intersection`, `safe_fuse`,
-  `translate`, `rotate`, `annular_boss`, and `raise_annulus`.
-- For imported STEP/BREP edits, `load_step(path)` returns a build123d `Part`:
-  ```python
-  base = load_step("v1_vendor/output.step")
-  solids = base.solids()
-  faces = base.faces()
-  edges = base.edges()
-  bounds = base.bounding_box()
-  ```
-  Use `agentcad measure` and `agentcad inspect` for read-only discovery; use
-  the loaded `Part` in a script when changing geometry. See
-  `agentcad docs editing` for the complete edit workflow.
-- When repeating an imported feature, use the pre-injected `rotate()` or
-  `translate()` helper on its raw shape. These helpers make an independent
-  geometry copy before moving it, preventing shared topology from corrupting
-  later Boolean results:
-  ```python
-  blade = load_step_shape("blade.step")
-  blade_72 = rotate(blade, "Z", 72)
-  ```
-  Use `copy_shape(blade)` when an independent, untransformed copy is needed.
-- For imported geometry Booleans, use `safe_cut(source, *tools)`,
-  `safe_intersection(left, right)`, and `safe_fuse(source, *tools)`. They copy
-  every input, run all tools together, validate the output, and reject
-  physically impossible volume changes instead of returning them silently.
-- For imported STEP annular edits, use the non-fuse workflow:
-  ```python
-  raw = load_step_shape("v1_vendor/output.step")
-  result = raise_annulus(raw, center=(0, 0), inner_diameter=40,
-                         outer_diameter=80, height=7, z=5)
-  show_object(Compound(result))
-  ```
-- For OCP internals (`gp_Pnt`, `BRepPrimAPI`, etc.), import manually.
-- CadQuery compatibility remains available for existing projects. See
-  `agentcad docs runtimes` for that separate workflow.
-
-## Key commands
-
-| Command | Purpose |
-|---------|---------|
-| `agentcad init --name NAME` | Initialize project |
-| `agentcad run SCRIPT --label LABEL` | Execute script, produce STEP + metrics |
-| `agentcad run ... --dry-run` | Metrics only, no version consumed |
-| `agentcad run ... --no-preview` | Suppress preview (on by default) |
-| `agentcad run ... --no-diff` | Suppress automatic prior-version comparison |
-| `agentcad run ... --no-view` | Suppress automatic browser review |
-| `agentcad run ... --render iso,front` | PNG views |
-| `agentcad run ... --export stl,glb` | Mesh export |
-| `agentcad run ... --params k=v,k=v` | Override script parameters |
-| `agentcad render STEP --view SPEC` | Post-hoc renders with camera control |
-| `agentcad export STEP --format stl,glb` | Post-hoc mesh export |
-| `agentcad measure STEP` | Dimensional report (overall metrics + feature sizes) |
-| `agentcad check-spec STEP spec.json` | Pass/fail checklist against intended cylindrical features |
-| `agentcad inspect STEP` | Bounded topology report with observable validation phases |
-| `agentcad parts list REF` | List parts captured for a version |
-| `agentcad parts show REF ID` | Show one versioned part by stable id |
-| `agentcad diff REF1 REF2` | Compare versions |
-| `agentcad context` | Project state and interrupted-version recovery candidates |
-| `agentcad recover VERSION_DIR` | Validate and reconcile interrupted history without deleting files |
-| `agentcad docs [SECTION]` | Runtime-aware built-in documentation |
-| `agentcad instructions install` | Record a short project note so future agents read `agentcad --help` |
-| `agentcad view FILE [FILE_B]` | Open one model or an explicit synchronized A/B comparison |
-
-`--label` names a version; read the generated file from `outputs.step`.
-`--output` remains a deprecated compatibility alias and is not a path option.
-
-## Debugging playbook
-
-1. **Check metrics first** — `volume` and `dimensions` catch most issues.
-2. **Read `preview.png`** — the 4-view composite. Fastest way to spot obvious problems.
-3. **Read `diff.side_by_side`** if iterating — confirms your change did what you intended.
-4. **Negative volume?** Wire winding is backwards (CW instead of CCW).
-5. **Need a hole diameter or edge length?** Run `agentcad measure output.step`.
-6. **Need to verify explicit hole/bore counts?** Write `spec.json`, then run
-   `agentcad check-spec output.step spec.json`.
-7. **is_valid: false?** Run `agentcad inspect` — check `free_edge_count` and shell status.
-8. **Hollow shape?** `free_edge_count > 0` means open shell.
-9. **Complex profiles (gears, splines)?** Use subtractive construction — cut from
-   a blank cylinder/box instead of building up. See `agentcad docs patterns`.
-10. **A run failed?** Trust `artifact_created: false` and `outputs.step: null`;
-    fix the script and execute the returned `next_actions` command. Do not write
-    or truncate STEP text — `agentcad run` or `agentcad import` must create it
-    through the CAD kernel.
-11. **Large inspect timed out?** It is not automatically malformed. Execute the
-    returned `--validate-only` action for a structural check, or the larger-budget
-    deep retry. Configure the default with `AGENTCAD_INSPECT_TIMEOUT_S`.
-
-## Patterns
-
-- **Build at origin, then position:** Create geometry at origin, use `translate()`
-  and `rotate()` to place it. These helpers copy imported topology before
-  transforming it.
-- **Compound vs fuse:** `Compound([...])` keeps assembly parts separate. Use
-  `safe_fuse(source, *tools)` when imported solids must become one union; use
-  build123d's `+` operator for ordinary newly constructed geometry.
-- **Parametric scripts:** Top-level variable assignments become overridable via
-  `--params`. Use this for iteration.
-- **Named parts:** `show_object(shape, id="wheel_left", name="Left wheel",
-  options={"color": "red"})` for stable part handles, per-part metrics, and
-  colored GLB export.
 """
 
-
-_CADQUERY_SCRIPT_RULES = """## Script writing rules
-
-- This is a CadQuery compatibility project. Keep scripts on the CadQuery API.
-- `show_object(result)` is required — at least one call.
-- `cq`, `show_object`, and compatibility helpers are pre-injected, so a basic
-  script needs no import:
-  ```python
-  part = cq.Workplane('XY').box(10, 20, 5)
-  show_object(part)
-  ```
-- Helpers that operate on `TopoDS_Shape` use `.val().wrapped` as the bridge:
-  ```python
-  part = cq.Workplane('XY').box(10, 20, 5).val().wrapped
-  moved = translate(part, 50, 0, 0)
-  ```
-- Imported-geometry Booleans should use `safe_cut`, `safe_intersection`, or
-  `safe_fuse`; these independently copy inputs and reject invalid or
-  physically impossible output.
-- To show raw helper output:
-  ```python
-  show_object(cq.Workplane('XY').newObject([cq.Shape.cast(topo_shape)]))
-  ```
-- For OCP internals (`gp_Pnt`, `BRepPrimAPI`, etc.), import manually.
+_CADQUERY_FRONTMATTER = """\
+---
+name: agentcad
+description: >
+  CAD tool for AI agents. Use when the user asks you to design, model, or build
+  a 3D object in an existing CadQuery compatibility project. agentcad
+  produces STEP files, PNG renders, mesh exports (STL/GLB/OBJ), and metrics.
+compatibility: Requires Python 3.10-3.12 and agentcad installed (pip install agentcad).
+allowed-tools: Bash(agentcad:*)
+---
 
 """
-
-
-_CADQUERY_PATTERNS = """## Patterns
-
-- **Build at origin, then position:** Create geometry at origin, use
-  `translate()` and `rotate()` to place it. These helpers copy imported
-  topology before transforming it.
-- **Compound vs union:** `makeCompound()` keeps assembly parts separate. Use
-  `safe_fuse(source, *tools)` for imported raw shapes; `.union()` remains fine
-  for ordinary newly constructed CadQuery geometry.
-- **Parametric scripts:** Top-level variable assignments become overridable via
-  `--params`. Use this for iteration.
-- **Named parts:** `show_object(shape, id="wheel_left", name="Left wheel",
-  options={"color": "red"})` creates stable part handles, per-part metrics, and
-  colored GLB output.
-"""
-
-
-def _cadquery_skill_content() -> str:
-    """Create a CadQuery-only compatibility skill from the shared workflow."""
-    content = SKILL_CONTENT
-    content = content.replace(
-        "a 3D object. agentcad executes build123d Python scripts and produces STEP\n"
-        "  files, PNG renders, mesh exports (STL/GLB/OBJ), and geometric metrics.",
-        "a 3D object in an existing CadQuery compatibility project. agentcad\n"
-        "  produces STEP files, PNG renders, mesh exports (STL/GLB/OBJ), and metrics.",
-    )
-    content = content.replace(
-        "You have access to `agentcad`, a CLI that turns build123d Python scripts into 3D\n"
-        "geometry.",
-        "You have access to `agentcad` in a CadQuery compatibility project. The CLI\n"
-        "turns CadQuery Python scripts into 3D geometry.",
-    )
-    content = content.replace(
-        "## First-time setup\n\n"
-        "```bash\n"
-        "agentcad init --name <project_name>\n"
-        "agentcad --help   # Read the built-in how-to guide and command reference\n"
-        "```",
-        "## CadQuery compatibility setup\n\n"
-        "```bash\n"
-        "agentcad init --name <project_name> --runtime cadquery\n"
-        "agentcad --help   # Read the project-scoped compatibility how-to guide\n"
-        "```",
-    )
-    content = content.replace(
-        "1. **Write a script.** No imports needed — build123d primitives,\n"
-        "   `show_object`, and agentcad edit helpers are pre-injected by default.\n"
-        "   `show_object(result)` is required.",
-        "1. **Write a script.** No imports needed — `cq`, `show_object`, and\n"
-        "   CadQuery compatibility helpers are pre-injected. At least one\n"
-        "   `show_object(result)` call is required.",
-    )
-    rules_start = content.index("## Script writing rules")
-    commands_start = content.index("## Key commands")
-    content = (
-        content[:rules_start]
-        + _CADQUERY_SCRIPT_RULES
-        + content[commands_start:]
-    )
-    content = content.replace(
-        "| `agentcad init --name NAME` | Initialize project |",
-        "| `agentcad init --name NAME --runtime cadquery` | Initialize compatibility project |",
-    )
-    patterns_start = content.index("## Patterns")
-    return content[:patterns_start] + _CADQUERY_PATTERNS
-
-
-def _effective_runtime(runtime: str | None) -> str:
-    return (
-        runtime
-        or dispatch.project_runtime(search_parents=True)
-        or dispatch.DEFAULT_RUNTIME
-    )
 
 
 def _skill_content(runtime: str) -> str:
-    if runtime == "cadquery":
-        return _cadquery_skill_content()
-    return SKILL_CONTENT
+    frontmatter = (
+        _CADQUERY_FRONTMATTER if runtime == "cadquery" else _BUILD123D_FRONTMATTER
+    )
+    return frontmatter + guide_body(runtime)
+
+
+def install_skill(cwd: Path, runtime: str) -> dict:
+    """Write the skill file for ``runtime`` and return install evidence."""
+    skill_path = cwd / SKILL_RELATIVE_PATH
+    skill_path.parent.mkdir(parents=True, exist_ok=True)
+    skill_path.write_text(_skill_content(runtime))
+    return {
+        "runtime": runtime,
+        "path": str(skill_path),
+        "guide_fingerprint": guide_fingerprint(runtime),
+    }
+
+
+def skill_status(cwd: Path, runtime: str) -> dict:
+    """Report whether the installed skill matches this package's guide."""
+    skill_path = cwd / SKILL_RELATIVE_PATH
+    if not skill_path.exists():
+        return {"state": "missing", "path": str(skill_path)}
+    try:
+        installed = skill_path.read_text()
+    except OSError:
+        return {"state": "missing", "path": str(skill_path)}
+    state = "current" if installed == _skill_content(runtime) else "stale"
+    return {"state": state, "path": str(skill_path)}
 
 
 @click.group()
@@ -366,12 +89,13 @@ def skill():
 )
 def show(runtime):
     """Print the skill file content as JSON."""
-    effective_runtime = _effective_runtime(runtime)
+    runtime = effective_runtime(runtime)
     click.echo(json.dumps({
         "command": "skill show",
         "status": "success",
-        "runtime": effective_runtime,
-        "content": _skill_content(effective_runtime),
+        "runtime": runtime,
+        "guide_fingerprint": guide_fingerprint(runtime),
+        "content": _skill_content(runtime),
     }))
 
 
@@ -384,16 +108,10 @@ def show(runtime):
 )
 def install(runtime):
     """Install the agent skill to .claude/skills/agentcad/SKILL.md."""
-    effective_runtime = _effective_runtime(runtime)
-    skill_dir = Path.cwd() / ".claude" / "skills" / "agentcad"
-    skill_dir.mkdir(parents=True, exist_ok=True)
-    skill_path = skill_dir / "SKILL.md"
-    skill_path.write_text(_skill_content(effective_runtime))
-
+    result = install_skill(Path.cwd(), effective_runtime(runtime))
     click.echo(json.dumps({
         "command": "skill install",
         "status": "success",
-        "runtime": effective_runtime,
-        "path": str(skill_path),
+        **result,
         "message": "Skill installed. Claude Code will auto-discover it in this project.",
     }))

--- a/src/agentcad/guide.py
+++ b/src/agentcad/guide.py
@@ -1,0 +1,355 @@
+"""Canonical agent operating guide.
+
+This module is the single source of truth for the guidance agents need to
+operate agentcad. Every installed surface — the Claude Code skill, the
+AGENTS.md/CLAUDE.md project-instruction block — renders from `guide_body()`,
+so the surfaces cannot drift from each other.
+
+`guide_fingerprint()` identifies the rendered content. Installers stamp it
+into managed files; `agentcad context` compares stamps against the running
+package to detect stale installs after an upgrade. The fingerprint is a
+content hash, not a manually bumped version, so it can never be forgotten.
+"""
+
+import hashlib
+
+from agentcad.runners import dispatch
+
+
+GUIDE_BODY = """\
+# agentcad — CAD tool for AI agents
+
+You have access to `agentcad`, a CLI that turns build123d Python scripts into 3D
+geometry. All output is JSON. Every command returns `"command"` and `"status"` keys.
+
+## First-time setup
+
+```bash
+agentcad init --name <project_name>
+agentcad --help   # Read the built-in how-to guide and command reference
+```
+
+If `agentcad.json` already exists, this project is already initialized — skip
+`init` and go straight to the core workflow.
+
+## Core workflow
+
+1. **Write a script.** No imports needed — build123d primitives,
+   `show_object`, and agentcad edit helpers are pre-injected by default.
+   `show_object(result)` is required.
+
+2. **Dry-run first** to check metrics without consuming a version:
+   ```bash
+   agentcad run script.py --label test --dry-run
+   ```
+   Check `volume`, `dimensions`, `is_valid` in the response.
+
+3. **Run for real.** Visual feedback is on by default:
+   ```bash
+   agentcad run script.py --label label
+   ```
+   A normal successful iteration can produce (paths in the JSON response):
+   - `preview.png` — balanced top, bottom, upper-iso, and lower-iso composite.
+     **Read this** to confirm the part looks right before iterating. The lower
+     views expose geometry that a top view can hide.
+   - `diff.side_by_side` — side-by-side PNG vs the most recent successful prior
+     version, when one exists and automatic diff is enabled. **Read this** when
+     iterating to see what your change did.
+   - `diff.overlay` — centered 2D visual-overlap map (coincident gray,
+     reference-only blue, candidate-only orange). It helps locate silhouette
+     changes but does not prove physical correctness or shared 3D volume.
+   - `viewer.html` — interactive 3D review viewer for the user unless viewer
+     artifacts are disabled (humans only;
+     you can't render HTML). It opens automatically after a successful run.
+     From v2, A=previous and B=current are already loaded with synchronized
+     A/B, side-by-side, overlay, diff-image, and Parts-tab change review.
+
+   Pass `--no-preview` only for tight parametric sweeps where latency matters.
+   Pass `--no-view` only when browser launch would disrupt an unattended or
+   high-volume run.
+
+   For a core-only iteration, pass
+   `--no-preview --no-diff --no-view`. This writes `output.step`, the saved
+   script, `meta.json` (including metrics), and explicitly requested exports
+   without generating previews, automatic comparisons, viewer assets, or
+   opening a browser. You can still run an explicit
+   `agentcad diff OLD NEW` later.
+
+   When a comparison is slow or incomplete, read `comparison_phases` in the
+   JSON response. `source_loading`, `comparison_rendering`,
+   `projection_comparison`, `exact_3d_comparison`,
+   `approximate_3d_comparison`, `difference_artifact_export`, and
+   `viewer_generation` each report a status
+   and, when attempted, `duration_ms`. The largest duration identifies the
+   expensive stage; a failed exact phase does not erase a successful projection.
+   Exact 3D work has a 30-second default worker budget. Set
+   `AGENTCAD_DIFF_TIMEOUT_S=N` to override it (`0` disables the dedicated limit
+   for diagnostics). A timeout leaves the core version and projection usable,
+   then runs a bounded voxel fallback. Approximate results report
+   `method=approximate_voxel_volume`, `resolution_mm`, and a non-strict
+   `error_estimate`; its `absolute_volume` values are heuristic errors, not
+   measurements. `exact_attempt` retains the exact failure. Use
+   `AGENTCAD_APPROX_DIFF_TIMEOUT_S` and `AGENTCAD_APPROX_RESOLUTION_MM` to tune
+   the fallback. If exact volumes are still needed, run
+   `agentcad diff OLD NEW` with a larger budget; do not rerun the original CAD
+   command and create a duplicate version.
+
+   Daemon-routed commands may run beyond 30 seconds. Progress heartbeats appear
+   on stderr while stdout stays reserved for the final JSON response, and the
+   submitted command is never automatically retried. If a silent or lost daemon
+   returns `outcome: "unknown"` and `retry_safe: false`, inspect `agentcad
+   context`, existing outputs, and `agentcad daemon status` before retrying; the
+   original command may already have completed.
+
+4. **Review with the user.** The generated viewer opens automatically. On v2+
+   start with its previous/current comparison, then use A/B, Overlay, and Parts
+   without selecting files manually. Use `agentcad view old.step new.step` only
+   for an explicit non-adjacent comparison.
+
+5. **Inspect if invalid.** If `is_valid: false` or geometry looks wrong:
+   ```bash
+   agentcad inspect v1_label/output.step
+   ```
+
+6. **Measure feature sizes.** For dimensions beyond top-level metrics:
+   ```bash
+   agentcad measure v1_label/output.step
+   ```
+   Use this for hole diameters, cylindrical boss diameters, edge lengths,
+   face areas, and full per-feature measurements with `--features`.
+
+7. **Check explicit feature requirements.** If the prompt names measurable
+   holes, bores, or cylindrical bosses, write them into `spec.json` before
+   final handoff:
+   ```json
+   {"features":[{"name":"bolt_holes","type":"cylinder","diameter_mm":6,"count":4}]}
+   ```
+   Then run:
+   ```bash
+   agentcad check-spec v1_label/output.step spec.json
+   ```
+   Revise the CAD if `passed` is false. `status: success` only means the
+   comparison ran; `passed` is the actual spec-check result. If you include
+   `axis`, copy it from `agentcad measure`'s `cylindrical_features[].axis`.
+
+8. **Iterate.** Fix the script, run with a new `--label` value. Use
+   `agentcad diff 1 2` to compare versions.
+
+## Script writing rules
+
+- `show_object(result)` is required — at least one call.
+- These are pre-injected by default (no import needed):
+  build123d primitives like `Box`, `Cylinder`, `Sphere`, `Plane`, plus
+  `show_object`, `load_step`, `pick_face`, `pick_edge`, `fillet_edges`,
+  `chamfer_edges`, `shell_faces`, `cut_pocket`, `boss`, `split_by_plane`,
+  `replace_face`, `copy_shape`, `safe_cut`, `safe_intersection`, `safe_fuse`,
+  `translate`, `rotate`, `annular_boss`, and `raise_annulus`.
+- For imported STEP/BREP edits, `load_step(path)` returns a build123d `Part`:
+  ```python
+  base = load_step("v1_vendor/output.step")
+  solids = base.solids()
+  faces = base.faces()
+  edges = base.edges()
+  bounds = base.bounding_box()
+  ```
+  Use `agentcad measure` and `agentcad inspect` for read-only discovery; use
+  the loaded `Part` in a script when changing geometry. See
+  `agentcad docs editing` for the complete edit workflow.
+- When repeating an imported feature, use the pre-injected `rotate()` or
+  `translate()` helper on its raw shape. These helpers make an independent
+  geometry copy before moving it, preventing shared topology from corrupting
+  later Boolean results:
+  ```python
+  blade = load_step_shape("blade.step")
+  blade_72 = rotate(blade, "Z", 72)
+  ```
+  Use `copy_shape(blade)` when an independent, untransformed copy is needed.
+- For imported geometry Booleans, use `safe_cut(source, *tools)`,
+  `safe_intersection(left, right)`, and `safe_fuse(source, *tools)`. They copy
+  every input, run all tools together, validate the output, and reject
+  physically impossible volume changes instead of returning them silently.
+- For imported STEP annular edits, use the non-fuse workflow:
+  ```python
+  raw = load_step_shape("v1_vendor/output.step")
+  result = raise_annulus(raw, center=(0, 0), inner_diameter=40,
+                         outer_diameter=80, height=7, z=5)
+  show_object(Compound(result))
+  ```
+- For OCP internals (`gp_Pnt`, `BRepPrimAPI`, etc.), import manually.
+- CadQuery compatibility remains available for existing projects. See
+  `agentcad docs runtimes` for that separate workflow.
+
+## Key commands
+
+| Command | Purpose |
+|---------|---------|
+| `agentcad init --name NAME` | Initialize project |
+| `agentcad run SCRIPT --label LABEL` | Execute script, produce STEP + metrics |
+| `agentcad run ... --dry-run` | Metrics only, no version consumed |
+| `agentcad run ... --no-preview` | Suppress preview (on by default) |
+| `agentcad run ... --no-diff` | Suppress automatic prior-version comparison |
+| `agentcad run ... --no-view` | Suppress automatic browser review |
+| `agentcad run ... --render iso,front` | PNG views |
+| `agentcad run ... --export stl,glb` | Mesh export |
+| `agentcad run ... --params k=v,k=v` | Override script parameters |
+| `agentcad render STEP --view SPEC` | Post-hoc renders with camera control |
+| `agentcad export STEP --format stl,glb` | Post-hoc mesh export |
+| `agentcad measure STEP` | Dimensional report (overall metrics + feature sizes) |
+| `agentcad check-spec STEP spec.json` | Pass/fail checklist against intended cylindrical features |
+| `agentcad inspect STEP` | Bounded topology report with observable validation phases |
+| `agentcad parts list REF` | List parts captured for a version |
+| `agentcad parts show REF ID` | Show one versioned part by stable id |
+| `agentcad diff REF1 REF2` | Compare versions |
+| `agentcad context` | Project state and interrupted-version recovery candidates |
+| `agentcad recover VERSION_DIR` | Validate and reconcile interrupted history without deleting files |
+| `agentcad docs [SECTION]` | Runtime-aware built-in documentation |
+| `agentcad instructions install` | Refresh this guide in AGENTS.md/CLAUDE.md |
+| `agentcad view FILE [FILE_B]` | Open one model or an explicit synchronized A/B comparison |
+
+`--label` names a version; read the generated file from `outputs.step`.
+`--output` remains a deprecated compatibility alias and is not a path option.
+
+## Debugging playbook
+
+1. **Check metrics first** — `volume` and `dimensions` catch most issues.
+2. **Read `preview.png`** — the 4-view composite. Fastest way to spot obvious problems.
+3. **Read `diff.side_by_side`** if iterating — confirms your change did what you intended.
+4. **Negative volume?** Wire winding is backwards (CW instead of CCW).
+5. **Need a hole diameter or edge length?** Run `agentcad measure output.step`.
+6. **Need to verify explicit hole/bore counts?** Write `spec.json`, then run
+   `agentcad check-spec output.step spec.json`.
+7. **is_valid: false?** Run `agentcad inspect` — check `free_edge_count` and shell status.
+8. **Hollow shape?** `free_edge_count > 0` means open shell.
+9. **Complex profiles (gears, splines)?** Use subtractive construction — cut from
+   a blank cylinder/box instead of building up. See `agentcad docs patterns`.
+10. **A run failed?** Trust `artifact_created: false` and `outputs.step: null`;
+    fix the script and execute the returned `next_actions` command. Do not write
+    or truncate STEP text — `agentcad run` or `agentcad import` must create it
+    through the CAD kernel.
+11. **Large inspect timed out?** It is not automatically malformed. Execute the
+    returned `--validate-only` action for a structural check, or the larger-budget
+    deep retry. Configure the default with `AGENTCAD_INSPECT_TIMEOUT_S`.
+
+## Patterns
+
+- **Build at origin, then position:** Create geometry at origin, use `translate()`
+  and `rotate()` to place it. These helpers copy imported topology before
+  transforming it.
+- **Compound vs fuse:** `Compound([...])` keeps assembly parts separate. Use
+  `safe_fuse(source, *tools)` when imported solids must become one union; use
+  build123d's `+` operator for ordinary newly constructed geometry.
+- **Parametric scripts:** Top-level variable assignments become overridable via
+  `--params`. Use this for iteration.
+- **Named parts:** `show_object(shape, id="wheel_left", name="Left wheel",
+  options={"color": "red"})` for stable part handles, per-part metrics, and
+  colored GLB export.
+"""
+
+
+_CADQUERY_SCRIPT_RULES = """## Script writing rules
+
+- This is a CadQuery compatibility project. Keep scripts on the CadQuery API.
+- `show_object(result)` is required — at least one call.
+- `cq`, `show_object`, and compatibility helpers are pre-injected, so a basic
+  script needs no import:
+  ```python
+  part = cq.Workplane('XY').box(10, 20, 5)
+  show_object(part)
+  ```
+- Helpers that operate on `TopoDS_Shape` use `.val().wrapped` as the bridge:
+  ```python
+  part = cq.Workplane('XY').box(10, 20, 5).val().wrapped
+  moved = translate(part, 50, 0, 0)
+  ```
+- Imported-geometry Booleans should use `safe_cut`, `safe_intersection`, or
+  `safe_fuse`; these independently copy inputs and reject invalid or
+  physically impossible output.
+- To show raw helper output:
+  ```python
+  show_object(cq.Workplane('XY').newObject([cq.Shape.cast(topo_shape)]))
+  ```
+- For OCP internals (`gp_Pnt`, `BRepPrimAPI`, etc.), import manually.
+
+"""
+
+
+_CADQUERY_PATTERNS = """## Patterns
+
+- **Build at origin, then position:** Create geometry at origin, use
+  `translate()` and `rotate()` to place it. These helpers copy imported
+  topology before transforming it.
+- **Compound vs union:** `makeCompound()` keeps assembly parts separate. Use
+  `safe_fuse(source, *tools)` for imported raw shapes; `.union()` remains fine
+  for ordinary newly constructed CadQuery geometry.
+- **Parametric scripts:** Top-level variable assignments become overridable via
+  `--params`. Use this for iteration.
+- **Named parts:** `show_object(shape, id="wheel_left", name="Left wheel",
+  options={"color": "red"})` creates stable part handles, per-part metrics, and
+  colored GLB output.
+"""
+
+
+def _cadquery_guide_body() -> str:
+    """Create the CadQuery-only compatibility guide from the shared workflow."""
+    content = GUIDE_BODY
+    content = content.replace(
+        "You have access to `agentcad`, a CLI that turns build123d Python scripts into 3D\n"
+        "geometry.",
+        "You have access to `agentcad` in a CadQuery compatibility project. The CLI\n"
+        "turns CadQuery Python scripts into 3D geometry.",
+    )
+    content = content.replace(
+        "## First-time setup\n\n"
+        "```bash\n"
+        "agentcad init --name <project_name>\n"
+        "agentcad --help   # Read the built-in how-to guide and command reference\n"
+        "```",
+        "## CadQuery compatibility setup\n\n"
+        "```bash\n"
+        "agentcad init --name <project_name> --runtime cadquery\n"
+        "agentcad --help   # Read the project-scoped compatibility how-to guide\n"
+        "```",
+    )
+    content = content.replace(
+        "1. **Write a script.** No imports needed — build123d primitives,\n"
+        "   `show_object`, and agentcad edit helpers are pre-injected by default.\n"
+        "   `show_object(result)` is required.",
+        "1. **Write a script.** No imports needed — `cq`, `show_object`, and\n"
+        "   CadQuery compatibility helpers are pre-injected. At least one\n"
+        "   `show_object(result)` call is required.",
+    )
+    rules_start = content.index("## Script writing rules")
+    commands_start = content.index("## Key commands")
+    content = (
+        content[:rules_start]
+        + _CADQUERY_SCRIPT_RULES
+        + content[commands_start:]
+    )
+    content = content.replace(
+        "| `agentcad init --name NAME` | Initialize project |",
+        "| `agentcad init --name NAME --runtime cadquery` | Initialize compatibility project |",
+    )
+    patterns_start = content.index("## Patterns")
+    return content[:patterns_start] + _CADQUERY_PATTERNS
+
+
+def effective_runtime(runtime: str | None) -> str:
+    """Resolve an explicit runtime override against the project mode."""
+    return (
+        runtime
+        or dispatch.project_runtime(search_parents=True)
+        or dispatch.DEFAULT_RUNTIME
+    )
+
+
+def guide_body(runtime: str) -> str:
+    """The canonical operating guide, without any surface-specific wrapper."""
+    if runtime == "cadquery":
+        return _cadquery_guide_body()
+    return GUIDE_BODY
+
+
+def guide_fingerprint(runtime: str) -> str:
+    """Short content hash identifying this package's rendered guide."""
+    digest = hashlib.sha256(guide_body(runtime).encode("utf-8")).hexdigest()
+    return digest[:12]

--- a/tests/test_agent_guide.py
+++ b/tests/test_agent_guide.py
@@ -1,0 +1,203 @@
+"""The canonical agent guide and its automatic installation.
+
+Three properties matter:
+
+1. Every surface (skill, instructions block) renders the same canonical body,
+   so they cannot drift from each other.
+2. `agentcad init` installs the guide by default — a user who runs only
+   `pip install agentcad` + `agentcad init` gets an AGENTS.md block that
+   harnesses load unconditionally, plus the Claude Code skill.
+3. `agentcad context` detects missing/stale installs and suggests the repair
+   without mutating anything.
+"""
+
+import json
+from pathlib import Path
+
+from agentcad.cli import cli
+from agentcad.commands.init import _bootstrap_manifest
+from agentcad.commands.instructions import END_MARKER, START_MARKER
+from agentcad.guide import guide_body, guide_fingerprint
+
+
+def _invoke(runner, args):
+    result = runner.invoke(cli, args)
+    assert result.exit_code == 0, result.output
+    return json.loads(result.stdout)
+
+
+# --- one canonical body across surfaces ---
+
+
+def test_skill_and_instructions_render_the_same_canonical_body(runner):
+    for runtime in ("build123d", "cadquery"):
+        body = guide_body(runtime)
+        skill = _invoke(runner, ["skill", "show", "--runtime", runtime])
+        instructions = _invoke(
+            runner, ["instructions", "show", "--runtime", runtime]
+        )
+        assert skill["content"].endswith(body)
+        assert body.rstrip() in instructions["content"]
+        assert skill["guide_fingerprint"] == guide_fingerprint(runtime)
+        assert instructions["guide_fingerprint"] == guide_fingerprint(runtime)
+
+
+def test_runtime_guides_differ_and_have_distinct_fingerprints():
+    assert guide_body("build123d") != guide_body("cadquery")
+    assert guide_fingerprint("build123d") != guide_fingerprint("cadquery")
+
+
+# --- init installs the guide by default ---
+
+
+def test_init_installs_instructions_and_skill(runner, isolated_dir):
+    payload = _invoke(runner, ["init", "--name", "widget"])
+
+    setup = payload["agent_setup"]
+    assert setup["status"] == "ready"
+    assert setup["guide_fingerprint"] == guide_fingerprint("build123d")
+    target_names = {t["name"] for t in setup["targets"]}
+    assert target_names == {"claude-skill", "project-instructions"}
+    # uniform schema: every target lists its files under "paths"
+    assert all(isinstance(t["paths"], list) for t in setup["targets"])
+
+    agents = (isolated_dir / "AGENTS.md").read_text()
+    assert START_MARKER in agents
+    assert guide_fingerprint("build123d") in agents
+    assert guide_body("build123d").rstrip() in agents
+
+    skill_file = isolated_dir / ".claude" / "skills" / "agentcad" / "SKILL.md"
+    assert skill_file.read_text().endswith(guide_body("build123d"))
+
+
+def test_init_no_agent_setup_installs_nothing(runner, isolated_dir):
+    payload = _invoke(runner, ["init", "--no-agent-setup"])
+
+    assert payload["agent_setup"] == {"status": "skipped"}
+    assert not (isolated_dir / "AGENTS.md").exists()
+    assert not (isolated_dir / ".claude").exists()
+
+
+def test_init_preserves_user_authored_instructions(runner, isolated_dir):
+    claude = isolated_dir / "CLAUDE.md"
+    claude.write_text("# Project\n\nUse tabs, not spaces.\n")
+
+    _invoke(runner, ["init"])
+
+    content = claude.read_text()
+    assert "Use tabs, not spaces." in content
+    assert content.count(START_MARKER) == 1
+    assert content.count(END_MARKER) == 1
+    # auto target updates the existing file rather than creating a second one
+    assert not (isolated_dir / "AGENTS.md").exists()
+
+
+def test_init_cadquery_project_installs_cadquery_guide(runner, isolated_dir):
+    _invoke(runner, ["init", "--runtime", "cadquery"])
+
+    agents = (isolated_dir / "AGENTS.md").read_text()
+    assert "cq.Workplane" in agents
+    assert "build123d primitives" not in agents
+
+    skill_file = isolated_dir / ".claude" / "skills" / "agentcad" / "SKILL.md"
+    assert "cq.Workplane" in skill_file.read_text()
+
+
+def test_import_bootstrap_installs_guide(runner, isolated_dir, monkeypatch):
+    monkeypatch.chdir(isolated_dir)
+    _bootstrap_manifest(runtime="build123d")
+
+    assert (isolated_dir / "AGENTS.md").exists()
+    assert (
+        isolated_dir / ".claude" / "skills" / "agentcad" / "SKILL.md"
+    ).exists()
+
+
+# --- context detects current / stale / missing ---
+
+
+def test_context_reports_current_after_init(runner, isolated_dir):
+    _invoke(runner, ["init"])
+    payload = _invoke(runner, ["context"])
+
+    setup = payload["agent_setup"]
+    assert setup["instructions"]["state"] == "current"
+    assert setup["skill"]["state"] == "current"
+    assert "next_actions" not in payload
+
+
+def test_context_reports_missing_setup_with_repair_actions(
+    runner, isolated_dir
+):
+    _invoke(runner, ["init", "--no-agent-setup"])
+    payload = _invoke(runner, ["context"])
+
+    setup = payload["agent_setup"]
+    assert setup["instructions"]["state"] == "missing"
+    assert setup["skill"]["state"] == "missing"
+    actions = payload["next_actions"]
+    assert any("instructions install" in action for action in actions)
+    assert any("skill install" in action for action in actions)
+
+
+def test_context_reports_stale_setup_after_content_change(
+    runner, isolated_dir
+):
+    _invoke(runner, ["init"])
+
+    # Simulate a pre-upgrade install: old fingerprint, old skill content.
+    agents = isolated_dir / "AGENTS.md"
+    agents.write_text(
+        agents.read_text().replace(guide_fingerprint("build123d"), "0" * 12)
+    )
+    skill_file = isolated_dir / ".claude" / "skills" / "agentcad" / "SKILL.md"
+    skill_file.write_text(skill_file.read_text() + "\nlocal edit\n")
+
+    payload = _invoke(runner, ["context"])
+    setup = payload["agent_setup"]
+    assert setup["instructions"]["state"] == "stale"
+    assert setup["skill"]["state"] == "stale"
+    assert any("refresh" in action for action in payload["next_actions"])
+
+
+def test_guide_warns_against_rerunning_init():
+    for runtime in ("build123d", "cadquery"):
+        assert "already initialized" in guide_body(runtime)
+
+
+def test_second_init_suggests_guide_refresh_not_force(runner, isolated_dir):
+    _invoke(runner, ["init"])
+    result = runner.invoke(cli, ["init"])
+    assert result.exit_code == 1
+    parsed = json.loads(result.stdout)
+    assert "already initialized" in parsed["suggestion"]
+    assert "instructions install" in parsed["suggestion"]
+
+
+def test_repeated_install_keeps_block_at_top_without_blank_lines(
+    runner, isolated_dir
+):
+    _invoke(runner, ["init"])
+    _invoke(runner, ["instructions", "install"])
+    _invoke(runner, ["instructions", "install"])
+
+    content = (isolated_dir / "AGENTS.md").read_text()
+    assert content.startswith(START_MARKER)
+    assert content.count(START_MARKER) == 1
+
+
+def test_instructions_install_replaces_stale_block_only(runner, isolated_dir):
+    agents = isolated_dir / "AGENTS.md"
+    agents.write_text(
+        "# Project\n\n"
+        f"{START_MARKER}\nold pointer block\n{END_MARKER}\n\n"
+        "Keep this.\n"
+    )
+
+    _invoke(runner, ["instructions", "install"])
+
+    content = agents.read_text()
+    assert "old pointer block" not in content
+    assert "Keep this." in content
+    assert guide_body("build123d").rstrip() in content
+    assert content.count(START_MARKER) == 1


### PR DESCRIPTION
## Summary

Implements the public-repo portion of the "make the distributed agent guide automatic" product requirement (internal #305). Agents were getting bare-CLI behavior because the guide that doubles benchmark performance was opt-in — nothing installed it, and installing it didn't guarantee it reached the agent's context.

- **One canonical guide** (`src/agentcad/guide.py`): runtime-aware (build123d/CadQuery), identified by a SHA-256 content fingerprint. The Claude skill and the AGENTS.md/CLAUDE.md block both render from it; a drift test pins that they cannot diverge.
- **The instructions block is now the full guide, not a pointer.** Instruction files are loaded unconditionally by agent harnesses, so the guide is in context before the first CAD action — the condition that produced the Candidate C benchmark result. The skill file remains as belt-and-suspenders for skill-aware harnesses.
- **`agentcad init` (and `import --init`) installs both surfaces by default**, reports an `agent_setup` evidence object (fingerprint, targets, activation mode), and takes `--no-agent-setup` to opt out. User-authored instruction content is preserved via the existing start/end markers.
- **`agentcad agent status`-style diagnostics live in `agentcad context`**: per-surface current/stale/missing state plus the exact repair command in `next_actions`. Context never mutates files.
- README quick start and `--help` updated. `skill install` / `instructions install` remain as refresh commands. No commands or docs sections added, so the public-surface snapshot and the agentcad.dev mirror are unchanged.

## Verification

- Full suite: 1424 passed, 2 skipped.
- New `tests/test_agent_guide.py`: surface-drift pinning, default install, `--no-agent-setup`, user-content preservation, cadquery runtime, stale/missing detection and repair, idempotent re-install.
- Fresh-agent friction check (per CLAUDE.md): a sub-agent following only README + installed AGENTS.md completed init → script → run → measure without ever being told about `skill install`/`instructions install`; the stale-guide repair loop was self-healing from JSON alone. Its findings (guide telling initialized projects to re-run init, second-init error steering to `--force`, `path`/`paths` schema inconsistency, blank-line accumulation on refresh) are fixed in this PR.

Still owed from the internal harness: the frozen 8-fixture GPT-5 Nano edit diagnostic comparing automatic setup vs. explicitly loaded skill vs. bare CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)